### PR TITLE
Improve memory usage in features pipeline

### DIFF
--- a/eogrow/pipelines/features.py
+++ b/eogrow/pipelines/features.py
@@ -12,7 +12,6 @@ from eolearn.core import (
     EOWorkflow,
     FeatureType,
     LoadTask,
-    MergeEOPatchesTask,
     MergeFeatureTask,
     OverwritePermission,
     SaveTask,

--- a/eogrow/pipelines/features.py
+++ b/eogrow/pipelines/features.py
@@ -70,6 +70,7 @@ class FeaturesPipeline(Pipeline):
             ),
         )
 
+        dtype: Optional[str] = Field(description="The dtype under which the concatenated features should be saved")
         output_feature_name: str = Field(description="Name of output data feature encompassing bands and NDIs")
         compress_level: int = Field(1, description="Level of compression used in saving eopatches")
 
@@ -172,7 +173,9 @@ class FeaturesPipeline(Pipeline):
         """Tasks performed after temporal regularization. Should also prepare features for the saving step"""
         ndi_features = [(FeatureType.DATA, name) for name in self.config.ndis]
         merge_task = MergeFeatureTask(
-            [self._get_bands_feature(), *ndi_features], (FeatureType.DATA, self.config.output_feature_name)
+            [self._get_bands_feature(), *ndi_features],
+            (FeatureType.DATA, self.config.output_feature_name),
+            dtype=self.config.dtype,
         )
         return EONode(merge_task, inputs=[previous_node])
 

--- a/eogrow/pipelines/features.py
+++ b/eogrow/pipelines/features.py
@@ -159,15 +159,12 @@ class FeaturesPipeline(Pipeline):
 
     def get_ndi_node(self, previous_node: EONode) -> EONode:
         """Builds a node for constructing Normalized Difference Indices"""
-        ndi_nodes = []
+
         for name, (id1, id2) in self.config.ndis.items():
             ndi_task = NormalizedDifferenceIndexTask(self._get_bands_feature(), (FeatureType.DATA, name), [id1, id2])
-            ndi_nodes.append(EONode(ndi_task, inputs=[previous_node]))
+            previous_node = EONode(ndi_task, inputs=[previous_node])
 
-        if len(ndi_nodes) <= 1:
-            return ndi_nodes[0] if len(ndi_nodes) == 1 else previous_node
-
-        return EONode(MergeEOPatchesTask(), inputs=ndi_nodes)
+        return previous_node
 
     def get_postprocessing_node(self, previous_node: EONode) -> EONode:
         """Tasks performed after temporal regularization. Should also prepare features for the saving step"""


### PR DESCRIPTION
The pipeline now has an option for specifying the output dtype to allow reducing of memory needed for the data.

Despite the recent improvements to `MergeEOPatchTask` it causes some noticeable memory spikes due to data copying. For this reason parts of the pipeline have been linearized by hand (since it does not change the functionality) to deliver a less volatile memory consumption.