### PR TITLE
Add mypy action

### DIFF
--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -67,6 +67,29 @@ jobs:
           pip install isort
           isort . --diff --check
 
+  check-code-mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out current branch
+        if: github.event_name == 'push'
+        uses: actions/checkout@v2
+
+      - name: Setup Python
+        if: github.event_name == 'push'
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+          architecture: x64
+      
+      - name: Install packages
+        run: |
+          pip install -e .[DEV]
+      
+      - name: Run mypy
+        if: github.event_name == 'push'
+        run: |
+          mypy eogrow
+
   test-on-github:
     runs-on: ubuntu-latest
     strategy:

--- a/eogrow/core/config.py
+++ b/eogrow/core/config.py
@@ -282,7 +282,7 @@ def _recursive_apply_to_strings(config: object, function: Callable) -> object:
     return config
 
 
-def _recursive_check_config(config: dict) -> None:
+def _recursive_check_config(config: object) -> None:
     """Recursively checks if a config object conforms to some basic rules
 
     :raises: ValueError

--- a/eogrow/pipelines/merge_samples.py
+++ b/eogrow/pipelines/merge_samples.py
@@ -108,7 +108,7 @@ class MergeSamplesPipeline(Pipeline):
                 ]
                 feature_name = "TIMESTAMPS"
 
-            merged_array = np.concatenate(arrays, axis=0)
+            merged_array: np.ndarray = np.concatenate(arrays, axis=0)
             del arrays
 
             self._save_array(merged_array, feature_name)
@@ -125,7 +125,7 @@ class MergeSamplesPipeline(Pipeline):
                 for sample_num, patch_id in zip(patch_sample_nums, patch_ids)
             ]
 
-            merged_patch_ids = np.concatenate(patch_id_arrays, axis=0)
+            merged_patch_ids: np.ndarray = np.concatenate(patch_id_arrays, axis=0)
             self._save_array(merged_patch_ids, self.config.id_filename)
 
     @staticmethod

--- a/eogrow/tasks/features.py
+++ b/eogrow/tasks/features.py
@@ -170,7 +170,7 @@ class MaxNDVIMosaickingTask(MosaickingTask):
                 mosaic = feat_values[0]
             else:
                 indices = np.nanargmax(ndvi_values, axis=0).squeeze(axis=-1)
-                ixgrid = np.ix_(np.arange(timeframes), np.arange(height), np.arange(width))
+                ixgrid: Tuple[np.ndarray, ...] = np.ix_(np.arange(timeframes), np.arange(height), np.arange(width))
                 mosaic = feat_values[indices, ixgrid[1], ixgrid[2], :].squeeze(axis=0)
 
             mosaic[np.broadcast_to(mask_nan_slices[0], mosaic.shape)] = np.nan

--- a/eogrow/tasks/features.py
+++ b/eogrow/tasks/features.py
@@ -91,7 +91,7 @@ class MosaickingTask(EOTask, metaclass=abc.ABCMeta):
         edges.append(end)
         return np.array(edges)
 
-    def _find_time_indices(self, timestamps: Sequence[datetime], index: int) -> np.ndarray:
+    def _find_time_indices(self, timestamps: Sequence[datetime], index: int) -> Tuple[np.ndarray, ...]:
         """Compute indices of images to use for mosaicking"""
         if index == 1:
             array = np.where((np.array(timestamps) <= self.dates[index]))

--- a/eogrow/utils/testing.py
+++ b/eogrow/utils/testing.py
@@ -222,13 +222,14 @@ def run_and_test_pipeline(
     expected_stats_file = os.path.join(stats_folder, experiment_name + ".json")
 
     config = Config.from_path(config_filename)
-    try:
-        folder_key = folder_key or config.output_folder_key
-    except AttributeError:
-        raise ValueError("Pipeline does not have a `output_folder_key` parameter, `folder_key` must be set by hand.")
-
     if isinstance(config, ConfigList):
         raise ValueError("Cannot test config list with `run_and_test_pipeline`")
+
+    if folder_key or "output_folder_key" in config:
+        folder_key = folder_key or config.output_folder_key
+    else:
+        raise ValueError("Pipeline does not have a `output_folder_key` parameter, `folder_key` must be set by hand.")
+
     pipeline = load_pipeline(config)
 
     folder = pipeline.storage.get_folder(folder_key)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ markers = [
 ]
 
 [tool.mypy]
-follow_imports="normal"
+follow_imports = "normal"
 ignore_missing_imports = true
 show_column_numbers = true
 show_error_codes = true
@@ -25,3 +25,11 @@ no_implicit_optional = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 disallow_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_reexport = true
+warn_unreachable = true
+strict_equality = true
+# these ones are really strict, maybe later
+# disallow_untyped_calls = true
+# disallow_any_generics = true
+# warn_return_any = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,8 +7,12 @@ ipdb
 isort
 jupyter
 moto
+mypy
 pylint
 pytest-cov
 pytest-order
 pytest>=4.0.0
+types-requests
+types-setuptools
+types-urllib3
 twine


### PR DESCRIPTION
While using `mypy` in `eo-grow` is severely crippled by lack of types in `sh-py` and `eo-learn`, it would be shameful to not use it, since the code is 100% annotated.

I read up on how to install type stubs for packages, and there is the option of `mypy --install-types --no-interaction eogrow` the developers suggest that the best option is to install the via explicit mentions in the requirements file, so that versions can be fixed if needed. Using the above command also requires the type-checking to happen twice (the first one collects information on which stubs to install).