### PR TITLE
Updates for sentinelhub-py version 3.5.0

### DIFF
--- a/eogrow/core/area/batch.py
+++ b/eogrow/core/area/batch.py
@@ -6,8 +6,7 @@ from typing import Any, List
 from geopandas.geodataframe import GeoDataFrame
 from pydantic import Field
 
-from sentinelhub import BatchRequestStatus, BatchSplitter, BBox, SentinelHubBatch
-from sentinelhub.sentinelhub_batch import BatchRequest
+from sentinelhub import BatchRequest, BatchRequestStatus, BatchSplitter, BBox, SentinelHubBatch
 
 from .base import AreaManager
 

--- a/eogrow/core/eopatch.py
+++ b/eogrow/core/eopatch.py
@@ -7,7 +7,7 @@ import warnings
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import pandas
-from bidict import bidict  # type: ignore
+from bidict import bidict
 from geopandas import GeoDataFrame
 from pydantic import Field
 

--- a/eogrow/core/logging.py
+++ b/eogrow/core/logging.py
@@ -316,7 +316,7 @@ class StdoutFilter(Filter):
         "eogrow",
         "__main__",
         "root",
-        "sentinelhub.sentinelhub_batch",
+        "sentinelhub.api.batch",
     )
 
     def __init__(self, log_packages: Optional[Sequence[str]] = None, *args: Any, **kwargs: Any):

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ eo-learn-io>=1.0.0
 eo-learn-mask>=1.0.0
 eo-learn-ml-tools>=1.0.0
 eo-learn-visualization>=1.0.0
-sentinelhub>=3.4.0
+sentinelhub>=3.5.0


### PR DESCRIPTION
This PR is a consequence of https://github.com/sentinel-hub/sentinelhub-py/pull/250 and should be merge only after `sentinelhub-py` `3.5.0` is released. 