### PR TITLE
Handling case when userdata.json doesn't exist

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ black>=22.1.0
 responses < 0.19.0
 boto3
 codecov
+flake8
 fs_s3fs
 ipdb
 isort


### PR DESCRIPTION
A continuation of https://github.com/sentinel-hub/eo-grow/pull/29. This PR makes sure that even if `userdata.json` doesn't exist the pipeline succeeds if parameters for handling userdata are not defined.