### PR TITLE
Add seeds to tests for training pipelines, reduce amount of warnings

### DIFF
--- a/eogrow/pipelines/training.py
+++ b/eogrow/pipelines/training.py
@@ -115,7 +115,7 @@ class BaseTrainingPipeline(Pipeline, metaclass=abc.ABCMeta):
 
     def preprocess_data(self, features: np.ndarray, reference: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
         """Preforms filtering and other preprocessing before splitting data."""
-        return features, reference
+        return features, reference.ravel()
 
     def train_test_split(
         self, features: np.ndarray, reference: np.ndarray
@@ -193,6 +193,7 @@ class ClassificationTrainingPipeline(BaseTrainingPipeline, metaclass=abc.ABCMeta
     def preprocess_data(self, features: np.ndarray, reference: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
         """Preforms filtering and other preprocessing before splitting data."""
         config = self.config.preprocessing
+        reference = reference.ravel()
         if config is None:
             return features, reference
 

--- a/eogrow/utils/filter.py
+++ b/eogrow/utils/filter.py
@@ -20,7 +20,7 @@ def check_if_features_exist(
     """Checks whether an EOPatch in the given location has all specified features saved"""
     not_seen_features = set(features)
     try:
-        for (ftype, name, _) in walk_filesystem(filesystem, eopatch_path, features=features):
+        for ftype, name, _ in walk_filesystem(filesystem, eopatch_path, features=features):
             if (ftype, name) in not_seen_features:
                 not_seen_features.remove((ftype, name))
             elif ftype in not_seen_features:

--- a/tests/test_config_files/training/lgbm_training_label_filter.json
+++ b/tests/test_config_files/training/lgbm_training_label_filter.json
@@ -15,6 +15,7 @@
     "filter_classes": [1, 3, 4]
   },
   "model_parameters": {
+    "random_state": 42,
     "min_child_samples": 500,
     "n_estimators": 100,
     "n_jobs": -1

--- a/tests/test_config_files/training/lgbm_training_no_filter.json
+++ b/tests/test_config_files/training/lgbm_training_no_filter.json
@@ -11,6 +11,7 @@
     "train_size": 0.8
   },
   "model_parameters": {
+    "random_state": 42,
     "min_child_samples": 500,
     "n_estimators": 100,
     "n_jobs": -1


### PR DESCRIPTION
We usually left references in shape of `(n_samples, 1)`, so I added `ravel` to preprocessing so that functions no longer complain.