### PR TITLE
Improved "skip existing" functionality and a fix for using it in BatchToEOPatchPipeline.

### DIFF
--- a/eogrow/core/pipeline.py
+++ b/eogrow/core/pipeline.py
@@ -103,8 +103,14 @@ class Pipeline(EOGrowObject):
             )
 
         if self.config.skip_existing:
+            LOGGER.info("Checking which EOPatches can be skipped")
             filtered_patch_list = self.filter_patch_list(patch_list)
-            LOGGER.info("Skipped some patches, %d / %d remaining", len(filtered_patch_list), len(patch_list))
+
+            skip_message = (
+                "Skipped some EOPatches" if len(filtered_patch_list) < len(patch_list) else "No EOPatches were skipped"
+            )
+            LOGGER.info("%s, %d / %d remaining", skip_message, len(filtered_patch_list), len(patch_list))
+
             patch_list = filtered_patch_list
 
         return patch_list

--- a/eogrow/pipelines/batch_to_eopatch.py
+++ b/eogrow/pipelines/batch_to_eopatch.py
@@ -21,7 +21,7 @@ from eolearn.io import ImportFromTiffTask
 from ..core.pipeline import Pipeline
 from ..core.schemas import BaseSchema
 from ..tasks.batch_to_eopatch import DeleteFilesTask, FixImportedTimeDependentFeatureTask, LoadUserDataTask
-from ..utils.filter import get_patches_without_all_features
+from ..utils.filter import get_patches_with_missing_features
 from ..utils.types import Feature
 
 
@@ -76,7 +76,7 @@ class BatchToEOPatchPipeline(Pipeline):
     def filter_patch_list(self, patch_list: List[str]) -> List[str]:
         """EOPatches are filtered according to existence of specified output features"""
 
-        filtered_patch_list = get_patches_without_all_features(
+        filtered_patch_list = get_patches_with_missing_features(
             self.storage.filesystem,
             self.storage.get_folder(self.config.output_folder_key),
             patch_list,

--- a/eogrow/pipelines/batch_to_eopatch.py
+++ b/eogrow/pipelines/batch_to_eopatch.py
@@ -87,10 +87,15 @@ class BatchToEOPatchPipeline(Pipeline):
 
     def _get_output_features(self) -> List[Feature]:
         """Lists all features that the pipeline outputs."""
-        additional_features = [(x.feature_type, x.feature_name) for x in self.config.mapping]
+        features = [FeatureType.BBOX] + [(x.feature_type, x.feature_name) for x in self.config.mapping]
+
         if self.config.userdata_feature_name:
-            additional_features.append((FeatureType.META_INFO, self.config.userdata_feature_name))
-        return [FeatureType.BBOX, FeatureType.TIMESTAMP] + additional_features
+            features.append((FeatureType.META_INFO, self.config.userdata_feature_name))
+
+        if self.config.userdata_timestamp_reader:
+            features.append(FeatureType.TIMESTAMP)
+
+        return features
 
     def build_workflow(self) -> EOWorkflow:
         """Builds the workflow"""

--- a/eogrow/pipelines/download.py
+++ b/eogrow/pipelines/download.py
@@ -17,7 +17,7 @@ from sentinelhub import Band, DataCollection, MimeType, Unit, read_data
 from ..core.config import Config
 from ..core.pipeline import Pipeline
 from ..core.schemas import BaseSchema
-from ..utils.filter import get_patches_without_all_features
+from ..utils.filter import get_patches_with_missing_features
 from ..utils.types import Feature, Path, TimePeriod
 from ..utils.validators import (
     field_validator,
@@ -68,7 +68,7 @@ class BaseDownloadPipeline(Pipeline, metaclass=abc.ABCMeta):
     def filter_patch_list(self, patch_list: List[str]) -> List[str]:
         """EOPatches are filtered according to existence of specified output features"""
 
-        filtered_patch_list = get_patches_without_all_features(
+        filtered_patch_list = get_patches_with_missing_features(
             self.storage.filesystem,
             self.storage.get_folder(self.config.output_folder_key),
             patch_list,

--- a/eogrow/pipelines/features.py
+++ b/eogrow/pipelines/features.py
@@ -27,7 +27,7 @@ from ..tasks.features import (
     ValidDataFractionPredicate,
     join_valid_and_cloud_masks,
 )
-from ..utils.filter import get_patches_without_all_features
+from ..utils.filter import get_patches_with_missing_features
 from ..utils.types import Feature, TimePeriod
 from ..utils.validators import field_validator, parse_time_period
 
@@ -76,7 +76,7 @@ class FeaturesPipeline(Pipeline):
     def filter_patch_list(self, patch_list: List[str]) -> List[str]:
         """EOPatches are filtered according to existence of specified output features"""
 
-        filtered_patch_list = get_patches_without_all_features(
+        filtered_patch_list = get_patches_with_missing_features(
             self.storage.filesystem,
             self.storage.get_folder(self.config.output_folder_key),
             patch_list,

--- a/eogrow/pipelines/prediction.py
+++ b/eogrow/pipelines/prediction.py
@@ -10,7 +10,7 @@ from eolearn.core import EONode, EOWorkflow, FeatureType, LoadTask, MergeEOPatch
 
 from ..core.pipeline import Pipeline
 from ..tasks.prediction import ClassificationPredictionTask, RegressionPredictionTask
-from ..utils.filter import get_patches_without_all_features
+from ..utils.filter import get_patches_with_missing_features
 from ..utils.types import Feature
 
 
@@ -64,7 +64,7 @@ class BasePredictionPipeline(Pipeline, metaclass=abc.ABCMeta):
     def filter_patch_list(self, patch_list: List[str]) -> List[str]:
         """EOPatches are filtered according to existence of specified output features"""
 
-        filtered_patch_list = get_patches_without_all_features(
+        filtered_patch_list = get_patches_with_missing_features(
             self.storage.filesystem,
             self.storage.get_folder(self.config.output_folder_key),
             patch_list,

--- a/eogrow/pipelines/rasterize.py
+++ b/eogrow/pipelines/rasterize.py
@@ -30,7 +30,7 @@ from eolearn.io import VectorImportTask
 from ..core.config import Config
 from ..core.pipeline import Pipeline
 from ..core.schemas import BaseSchema
-from ..utils.filter import get_patches_without_all_features
+from ..utils.filter import get_patches_with_missing_features
 from ..utils.fs import LocalFile
 from ..utils.types import Feature
 from ..utils.vector import concat_gdf
@@ -105,7 +105,7 @@ class RasterizePipeline(Pipeline):
             self.vector_feature = parse_feature(self.config.vector_input)
 
     def filter_patch_list(self, patch_list: List[str]) -> List[str]:
-        filtered_patch_list = get_patches_without_all_features(
+        filtered_patch_list = get_patches_with_missing_features(
             self.storage.filesystem,
             self.storage.get_folder(self.config.output_folder_key),
             patch_list,

--- a/eogrow/pipelines/sampling.py
+++ b/eogrow/pipelines/sampling.py
@@ -14,7 +14,7 @@ from eolearn.ml_tools import BlockSamplingTask, FractionSamplingTask, GridSampli
 from ..core.config import Config
 from ..core.pipeline import Pipeline
 from ..tasks.common import ClassFilterTask
-from ..utils.filter import get_patches_without_all_features
+from ..utils.filter import get_patches_with_missing_features
 from ..utils.types import Feature
 
 
@@ -46,7 +46,7 @@ class BaseSamplingPipeline(Pipeline, metaclass=abc.ABCMeta):
 
     def filter_patch_list(self, patch_list: List[str]) -> List[str]:
         """Filter output EOPatches that have already been processed"""
-        filtered_patch_list = get_patches_without_all_features(
+        filtered_patch_list = get_patches_with_missing_features(
             self.storage.filesystem,
             self.storage.get_folder(self.config.output_folder_key),
             patch_list,

--- a/eogrow/utils/filter.py
+++ b/eogrow/utils/filter.py
@@ -30,7 +30,7 @@ def check_if_features_exist(
     return len(not_seen_features) == 0
 
 
-def get_patches_without_all_features(
+def get_patches_with_missing_features(
     filesystem: FS,
     patches_folder: str,
     patch_list: List[str],

--- a/eogrow/utils/filter.py
+++ b/eogrow/utils/filter.py
@@ -6,6 +6,7 @@ from typing import Iterable, List
 
 import fs
 from fs.base import FS
+from tqdm.auto import tqdm
 
 from eolearn.core.eodata_io import walk_filesystem
 
@@ -36,13 +37,26 @@ def get_patches_with_missing_features(
     patch_list: List[str],
     features: Iterable[Feature],
 ) -> List[str]:
-    """Filters out patches that already contain all features"""
+    """Filters out names of those EOPatches that are missing some given features.
+
+    :param filesystem: A filesystem object.
+    :param patches_folder: A path to folder with EOPatches, relative to `filesystem` object.
+    :param patch_list: A list of EOPatch names.
+    :param features: A list of EOPatch features.
+    :return: A sublist of `patch_list` with only EOPatch names that are missing some features.
+    """
     eopatch_paths = [fs.path.combine(patches_folder, eopatch) for eopatch in patch_list]
 
     def check_patch(eopatch_path: str) -> bool:
         return check_if_features_exist(filesystem, eopatch_path, features)
 
-    with ThreadPoolExecutor() as pool:
-        has_features_iter = pool.map(check_patch, eopatch_paths)
+    with ThreadPoolExecutor() as executor:
+        has_features_list = list(
+            tqdm(
+                executor.map(check_patch, eopatch_paths),
+                total=len(eopatch_paths),
+                desc="Checking EOPatches",
+            )
+        )
 
-    return [eopatch for eopatch, has_features in zip(patch_list, has_features_iter) if not has_features]
+    return [eopatch for eopatch, has_features in zip(patch_list, has_features_list) if not has_features]

--- a/tests/test_utils/test_filter.py
+++ b/tests/test_utils/test_filter.py
@@ -14,7 +14,7 @@ from moto import mock_s3
 from eolearn.core import EOPatch, FeatureType
 from sentinelhub import CRS, BBox
 
-from eogrow.utils.filter import check_if_features_exist, get_patches_without_all_features
+from eogrow.utils.filter import check_if_features_exist, get_patches_with_missing_features
 
 pytestmark = pytest.mark.fast
 
@@ -79,6 +79,6 @@ def test_check_if_features_exist(mock_s3fs, temp_fs, test_features, expected_res
         ([(FeatureType.DATA, "no_data"), (FeatureType.DATA, "data")], 5),
     ],
 )
-def test_get_patches_without_all_features(mock_s3fs, temp_fs, features, expected_num):
+def test_get_patches_with_missing_features(mock_s3fs, temp_fs, features, expected_num):
     for filesystem in [mock_s3fs, temp_fs]:
-        assert len(get_patches_without_all_features(filesystem, "/", PATCH_NAMES, features)) == expected_num
+        assert len(get_patches_with_missing_features(filesystem, "/", PATCH_NAMES, features)) == expected_num


### PR DESCRIPTION
Running `BatchToEOPatchPipeline` on 300K patches showed some flaws of "skip existing" functionality. This PR makes basic improvements:

- adds more logs and a progress bar to the filtering procedure,
- renames the filtering function because the previous name `get_patches_without_all_feature` could be interpreted as "get patches that has none of the give features".
- fixes a bug in providing output features in `BatchToEOPatchPipeline` where skipping existing didn't work if EOPatches didn't have timestamps.

A large problem remains - filtering EOPatches is still too slow if we parallelize it only over threads. We could parallelize it also over the cluster. For this I suggest implementing a bit more general parallelization utilities that can be used here. That can be done in future work.