### PR TITLE
Patch tests until AreaManager fix

### DIFF
--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -128,7 +128,6 @@ jobs:
         if: matrix.python-version != '3.9'
         run: |
           pytest -m "fast"
-          pytest -m "chain"
 
       - name: Run fast and chain integration tests
         if: matrix.python-version == '3.9'
@@ -137,6 +136,7 @@ jobs:
             --sh_client_id "${{ secrets.SH_CLIENT_ID }}" \
             --sh_client_secret "${{ secrets.SH_CLIENT_SECRET }}"
           pytest -m "fast"
+          pytest -m "chain"
 
   mirror-to-gitlab:
     if: github.event_name == 'push'

--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -128,6 +128,7 @@ jobs:
         if: matrix.python-version != '3.9'
         run: |
           pytest -m "fast"
+          pytest -m "chain"
 
       - name: Run fast and chain integration tests
         if: matrix.python-version == '3.9'

--- a/eogrow/core/area/custom_grid.py
+++ b/eogrow/core/area/custom_grid.py
@@ -31,7 +31,8 @@ class CustomGridAreaManager(AreaManager):
             ),
         )
 
-    config: Schema
+    # TODO: The AreaManager needs to be reworked until this is no longer an issue
+    config: Schema  # type: ignore
 
     def get_area_dataframe(self, *, crs: CRS = CRS.WGS84, **_: Any) -> gpd.GeoDataFrame:
         """Provides a single dataframe that defines an AOI


### PR DESCRIPTION
Does two things:
1. reenables `chain` test, since `eolearn` got updated
2. mutes the `CustomGridAreaManager` type issue so that we don't overlook other issues due to a known failure 