### PR TITLE
A few batch pipeline improvements

### DIFF
--- a/eogrow/cli.py
+++ b/eogrow/cli.py
@@ -155,7 +155,7 @@ class EOGrowCli:
             f"{EOGrowCli._command_namespace} -e {encoded_configs}"
             + "".join(f' -v "{cli_var_spec}"' for cli_var_spec in cli_variables)
             + "".join(f" -t {patch_index}" for patch_index in test_patches)
-            + ("; " if stop_cluster else "")  # Otherwise ray will incorrectly prepare a command for stopping a cluster
+            + ("; " if stop_cluster else "")  # Otherwise, ray will incorrectly prepare a command for stopping a cluster
         )
         flag_info = [("start", start_cluster), ("stop", stop_cluster), ("screen", use_screen), ("tmux", use_tmux)]
         exec_flags = " ".join(f"--{flag_name}" for flag_name, use_flag in flag_info if use_flag)

--- a/eogrow/core/eopatch.py
+++ b/eogrow/core/eopatch.py
@@ -101,10 +101,10 @@ class EOPatchManager(EOGrowObject):
         """Provides a list of EOPatch names
 
         :param folder: If it is specified it will join the folder with eopatch names and return a list of complete paths
-        :param id_list: A list of patch ids which should be provided. By default is set to None and all EOPatch names
+        :param id_list: A list of patch ids which should be provided. By default, is set to None and all EOPatch names
             will be provided
         :param filter_existing: If given a folder parameter this will check if EOPatches at the given location actually
-            exist. By default this is set to True which means it will make additional IO calls, which could be slow
+            exist. By default, this is set to True which means it will make additional IO calls, which could be slow
             if using s3.
         :return: A list of EOPatch folder names
         """
@@ -152,7 +152,7 @@ class EOPatchManager(EOGrowObject):
         :param filename: A filename (or entire file path) from where names of EOPatches will be loaded. Supported
             formats are JSON and TXT
         :param id_list: A list of EOPatch IDs which are the only ones required. The IDs are calculated according to
-            the complete list of EOPatches. By default no filtering is done.
+            the complete list of EOPatches. By default, no filtering is done.
         :return: A list of EOPatch names loaded from file (and maybe filtered)
         """
         if filename.endswith(".json"):
@@ -187,7 +187,7 @@ class EOPatchManager(EOGrowObject):
         return [self.name_to_bbox_map[eopatch_name] for eopatch_name in eopatch_list]
 
     def parse_eopatch_list(self, eopatch_list: Union[List[str], List[int]]) -> List[str]:
-        """Parses given list of EOPatches into a a standard format
+        """Parses given list of EOPatches into a standard format
 
         :param eopatch_list: Can either be a list of EOPatch names (or file paths) or a list of indices
         """
@@ -195,7 +195,7 @@ class EOPatchManager(EOGrowObject):
             raise ValueError(f"Expected a list of EOPatch names, got {eopatch_list}")
 
         if all(isinstance(name, str) for name in eopatch_list):
-            eopatch_list = cast(List[str], eopatch_list)  # informs mypy of the type, doesnt change anything
+            eopatch_list = cast(List[str], eopatch_list)  # informs mypy of the type, doesn't change anything
             eopatch_list = [os.path.basename(name) for name in eopatch_list]
 
             if set(eopatch_list) <= self.name_to_id_map.keys():

--- a/eogrow/core/logging.py
+++ b/eogrow/core/logging.py
@@ -257,7 +257,7 @@ class RegularBackupHandler(FilesystemHandler):
 
     def __init__(self, *args: Any, backup_interval: Union[float, int], **kwargs: Any):
         """
-        :param backup_interval: A minimal number of seconds before handler will backup the log file to the remote
+        :param backup_interval: A minimal number of seconds before handler will back up the log file to the remote
             location. The backup will only happen when the next log record will be emitted.
         """
         super().__init__(*args, **kwargs)
@@ -268,7 +268,7 @@ class RegularBackupHandler(FilesystemHandler):
     def emit(self, record: LogRecord) -> None:
         """Save a new record and backup to remote if the backup hasn't been done in the given amount of time.
 
-        IMPORTANT: Any new log produced in this method must not reach this handler again. Otherwise the process will
+        IMPORTANT: Any new log produced in this method must not reach this handler again. Otherwise, the process will
         get stuck waiting for a thread lock release. Make sure that you combine this handler with a Filter class that
         filters out logs from botocore and s3transfer!
         """
@@ -289,7 +289,7 @@ class EOExecutionHandler(FilesystemHandler):
     def emit(self, record: LogRecord) -> None:
         """Save a new record. In case a new node in EOWorkflow is started it will copy the log file to remote.
 
-        IMPORTANT: Any new log produced in this method must not reach this handler again. Otherwise the process will
+        IMPORTANT: Any new log produced in this method must not reach this handler again. Otherwise, the process will
         get stuck waiting for a thread lock release. Therefore, make sure that you combine this handler with a Filter
         class that filters out logs from botocore, s3transfer and anything else that could be possibly logged during
         `LocalFile.copy_to_remote` call!

--- a/eogrow/core/storage.py
+++ b/eogrow/core/storage.py
@@ -81,7 +81,7 @@ class StorageManager(EOGrowObject):
         EOExecution report folders
 
         :param show_files: If  `True` it will show also files inside the folders. Note that the number of files may be
-            huge. By default this is set to `False`.
+            huge. By default, this is set to `False`.
         :param return_str: If `True` it will return folder structure as a string. If `False` it will just print the
             visualization to stdout.
         :param exclude: A list of grep folder paths  to exclude from the structure return.

--- a/eogrow/pipelines/batch_to_eopatch.py
+++ b/eogrow/pipelines/batch_to_eopatch.py
@@ -220,7 +220,7 @@ class BatchToEOPatchPipeline(Pipeline):
             for node in nodes:
                 if isinstance(node.task, ImportFromTiffTask):
                     if node.name is None:
-                        raise RuntimeError("One of the ImportFromTiffTask nodes has not been tagget with filename.")
+                        raise RuntimeError("One of the ImportFromTiffTask nodes has not been tagged with filename.")
                     filename = node.name.split()[0]
                     path = f"{name}/{filename}"
                     single_exec_dict[node] = dict(filename=path)

--- a/eogrow/pipelines/download.py
+++ b/eogrow/pipelines/download.py
@@ -189,7 +189,7 @@ class DownloadPipeline(BaseDownloadPipeline):
 
         if data_collection.is_byoc:
             if not self.config.bands:
-                raise ValueError("Band names must be explicitly suplied when working with BYOC.")
+                raise ValueError("Band names must be explicitly supplied when working with BYOC.")
 
             data_collection = self.config.data_collection.define_from(
                 f"{self.config.data_collection.name}_WITH_BANDS",

--- a/eogrow/pipelines/download.py
+++ b/eogrow/pipelines/download.py
@@ -142,7 +142,7 @@ class CommonDownloadFields(BaseSchema):
 
     resolution: float = Field(description="Resolution of downloaded data in meters")
 
-    maxcc: Optional[float] = Field(ge=0, le=1)
+    maxcc: Optional[float] = Field(ge=0, le=1, description="Maximal cloud coverage filter.")
 
     resampling_type: Optional[ResamplingType] = Field(
         description="A type of downsampling and upsampling used by Sentinel Hub service. Default is NEAREST"

--- a/eogrow/pipelines/download_batch.py
+++ b/eogrow/pipelines/download_batch.py
@@ -52,9 +52,15 @@ class BatchDownloadPipeline(Pipeline):
         resampling_type: ResamplingType = Field(
             "NEAREST", description="A type of downsampling and upsampling used by Sentinel Hub service"
         )
-
+        maxcc: Optional[float] = Field(ge=0, le=1, description="Maximal cloud coverage filter.")
         mosaicking_order: Optional[MosaickingOrderType] = Field(
             description="The mosaicking order used by Sentinel Hub service"
+        )
+        input_data_kwargs: dict = Field(
+            default_factory=dict,
+            description=(
+                "Additional parameters to be passed to SentinelHubRequest.input_data method as other_args parameter."
+            ),
         )
 
         batch_output_kwargs: dict = Field(
@@ -166,7 +172,9 @@ class BatchDownloadPipeline(Pipeline):
                     time_interval=self.config.time_period,
                     upsampling=self.config.resampling_type,
                     downsampling=self.config.resampling_type,
+                    maxcc=self.config.maxcc,
                     mosaicking_order=self.config.mosaicking_order,
+                    other_args=self.config.input_data_kwargs,
                 )
             ],
             responses=responses,

--- a/eogrow/pipelines/download_batch.py
+++ b/eogrow/pipelines/download_batch.py
@@ -190,7 +190,7 @@ class BatchDownloadPipeline(Pipeline):
             tiling_grid=SentinelHubBatch.tiling_grid(
                 grid_id=self.config.area.tiling_grid_id,
                 resolution=self.config.area.resolution,
-                buffer=(self.config.area.tile_buffer, self.config.area.tile_buffer),
+                buffer=(self.config.area.tile_buffer_x, self.config.area.tile_buffer_y),
             ),
             output=SentinelHubBatch.output(
                 default_tile_path=f"{data_folder}/<tileName>/<outputId>.<format>", **self.config.batch_output_kwargs

--- a/eogrow/pipelines/sampling.py
+++ b/eogrow/pipelines/sampling.py
@@ -21,9 +21,7 @@ class BaseSamplingPipeline(Pipeline, metaclass=abc.ABCMeta):
     """Pipeline to run sampling on EOPatches"""
 
     class Schema(Pipeline.Schema):
-        output_folder_key: str = Field(
-            description="The storage manager key pointing to the pipeline output folder."
-        )
+        output_folder_key: str = Field(description="The storage manager key pointing to the pipeline output folder.")
         apply_to: Dict[str, Dict[str, List[str]]] = Field(
             description=(
                 "A dictionary defining which features to sample, its structure is "

--- a/eogrow/pipelines/sampling.py
+++ b/eogrow/pipelines/sampling.py
@@ -22,7 +22,7 @@ class BaseSamplingPipeline(Pipeline, metaclass=abc.ABCMeta):
 
     class Schema(Pipeline.Schema):
         output_folder_key: str = Field(
-            description="The storage manager key pointing to the output folder for the Sampline pipeline."
+            description="The storage manager key pointing to the pipeline output folder."
         )
         apply_to: Dict[str, Dict[str, List[str]]] = Field(
             description=(

--- a/eogrow/pipelines/training.py
+++ b/eogrow/pipelines/training.py
@@ -1,5 +1,5 @@
 """
-Module implementing pipelines for training a ML classifier
+Module implementing pipelines for training an ML classifier
 """
 import abc
 import logging
@@ -38,7 +38,7 @@ class RandomTrainTestSplitSchema(BaseSchema):
 
 
 class BaseTrainingPipeline(Pipeline, metaclass=abc.ABCMeta):
-    """A base pipeline for training a ML model
+    """A base pipeline for training an ML model
 
     This class has a few abstract methods which have to be implemented. But in general all public methods are designed
     in a way that you can override them in a child class
@@ -168,7 +168,7 @@ class BaseTrainingPipeline(Pipeline, metaclass=abc.ABCMeta):
         """Scores the resulting model and reports the metrics into the log files."""
 
     def predict(self, model: Any, features: np.ndarray) -> np.ndarray:  # pylint: disable=no-self-use
-        """Evaluates model on features. Should be overriden for models with a different interface."""
+        """Evaluates model on features. Should be overridden for models with a different interface."""
         return model.predict(features)
 
 
@@ -187,7 +187,7 @@ class ClassificationPreprocessSchema(BaseSchema):
 
 
 class ClassificationTrainingPipeline(BaseTrainingPipeline, metaclass=abc.ABCMeta):
-    """A base pipeline for training a ML classifier. Uses LGBMClassifier by default."""
+    """A base pipeline for training an ML classifier. Uses LGBMClassifier by default."""
 
     class Schema(BaseTrainingPipeline.Schema):
         preprocessing: Optional[ClassificationPreprocessSchema]
@@ -240,7 +240,7 @@ class ClassificationTrainingPipeline(BaseTrainingPipeline, metaclass=abc.ABCMeta
 
 
 class RegressionTrainingPipeline(BaseTrainingPipeline):
-    """A base pipeline for training a ML regressor. Uses LGBMRegressor by default."""
+    """A base pipeline for training an ML regressor. Uses LGBMRegressor by default."""
 
     def train_model(self, prepared_data: dict) -> object:
         train_features = prepared_data["features_train"]

--- a/eogrow/utils/testing.py
+++ b/eogrow/utils/testing.py
@@ -27,10 +27,10 @@ class ContentTester:
     utility aggregates all folder content into some basic statistics.
 
     * Every time you initialize this class statistics will be calculated
-    * Statistics can be saved into a JSON file (it's human readable)
-    * Statistics can be compared compared with the one saved in a file from the previous run.
+    * Statistics can be saved into a JSON file (it's human-readable)
+    * Statistics can be compared with the one saved in a file from the previous run.
 
-    If statistics match there is a good chance that the pipeline produced exactly the same results as before. Otherwise
+    If statistics match there is a good chance that the pipeline produced exactly the same results as before. Otherwise,
     this utility will let you know which statistics does not match
     """
 
@@ -166,7 +166,7 @@ class ContentTester:
         return self._calculate_raster_stats(raster)
 
     def _calculate_vector_stats(self, dataframe: pd.DataFrame) -> List[object]:
-        """Calculates statistics over a vector GeoDataFrame"""  # TODO: add more statistical properites
+        """Calculates statistics over a vector GeoDataFrame"""  # TODO: add more statistical properties
         rounder = functools.partial(_round_point_coords, decimals=self.decimals)
         dataframe["geometry"] = dataframe["geometry"].apply(lambda geometry: shapely.ops.transform(rounder, geometry))
 
@@ -215,8 +215,8 @@ def run_and_test_pipeline(
     :param stats_folder: A path to folder containing the file with expected result stats
     :param folder_key: Type of the folder containing results of the pipeline, if missing it's inferred from config
     :param reset_folder: If True it will delete content of the folder with results before running the pipeline
-    :param save_new_stats: If True then new file with expected result stats will be saved (potentially overwriting the
-        old one. Otherwise the old one will be used to compare stats.
+    :param save_new_stats: If True then new file with expected result stats will be saved, potentially overwriting the
+        old one. Otherwise, the old one will be used to compare stats.
     """
     config_filename = os.path.join(config_folder, experiment_name + ".json")
     expected_stats_file = os.path.join(stats_folder, experiment_name + ".json")

--- a/eogrow/utils/vector.py
+++ b/eogrow/utils/vector.py
@@ -14,7 +14,7 @@ from sentinelhub import CRS
 def concat_gdf(dataframe_list: List[GeoDataFrame], reproject_crs: Union[CRS, int, None] = None) -> GeoDataFrame:
     """Concatenates together multiple GeoDataFrames, all in the same CRS
 
-    There exists pandas.concat but no geopandas.concat. Therefore this function implements it.
+    There exists pandas.concat but no geopandas.concat. Therefore, this function implements it.
 
     :param dataframe_list: A list of GeoDataFrames to be concatenated together
     :param reproject_crs: A CRS in which dataframes should be reprojected before being joined


### PR DESCRIPTION
Changes:
- added support for `maxcc` and `other_params` in batch pipeline,
- replaced `tile_buffer` with `tile_buffer_x` and `tile_buffer_y` in batch area manager,
- separated input data parameters into a sub-schema in batch pipeline and therefore allowing potential data fusion use cases,
- fixed various spelling mistakes in the package.

2nd and 3rd change on the list are code/config breaking but I think they are worth doing now while we still don't have that many use cases.