### PR TITLE
Increased rounding error for bounding boxes obtained from SH service

### DIFF
--- a/eogrow/core/area/batch.py
+++ b/eogrow/core/area/batch.py
@@ -48,6 +48,7 @@ class BatchAreaManager(AreaManager):
 
     config: Schema
     _BATCH_GRID_COLUMNS = ["index_n", "id", "name", "split_x", "split_y"]
+    _SH_REPROJECTION_ERROR = 1e-3  # Rounding happens in Sentinel Hub Batch database where coordinates are in WGS84
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
@@ -122,7 +123,7 @@ class BatchAreaManager(AreaManager):
 
     def _fix_batch_bbox(self, bbox: BBox) -> BBox:
         """Fixes a batch tile bounding box so that it will be the same as in produced tiles on the bucket."""
-        corrected_bbox = convert_bbox_coords_to_int(bbox)
+        corrected_bbox = convert_bbox_coords_to_int(bbox, error=self._SH_REPROJECTION_ERROR)
         return corrected_bbox.buffer(self.absolute_buffer, relative=False)
 
     @staticmethod


### PR DESCRIPTION
In my example the coordinate was `6149999.999867183` therefore I had to increase accepted rounding error from `1e-8` to `1e-3`. There might be cases with even larger error but we'll handle them when we get them.