### PR TITLE
LocalFolder and improvements in logging and prediction pipelines

### DIFF
--- a/eogrow/core/logging.py
+++ b/eogrow/core/logging.py
@@ -9,6 +9,7 @@ from logging import FileHandler, Filter, Formatter, Handler, LogRecord, StreamHa
 from typing import Any, List, Optional, Sequence, Union
 
 import fs
+from fs.base import FS
 from fs.errors import FilesystemClosed
 from pydantic import Field
 
@@ -224,9 +225,7 @@ class FilesystemHandler(FileHandler):
     process stuck waiting for a thread lock release.
     """
 
-    def __init__(
-        self, path: str, filesystem: Optional[fs.base.FS] = None, config: Optional[SHConfig] = None, **kwargs: Any
-    ):
+    def __init__(self, path: str, filesystem: Optional[FS] = None, config: Optional[SHConfig] = None, **kwargs: Any):
         """
         :param path: A path to a log file. It should be an absolute path if filesystem object is not given and relative
             otherwise.

--- a/eogrow/pipelines/prediction.py
+++ b/eogrow/pipelines/prediction.py
@@ -49,7 +49,6 @@ class BasePredictionPipeline(Pipeline, metaclass=abc.ABCMeta):
         model_folder_key: str = Field(
             description="The storage manager key pointing to the folder of the model used in the prediction pipeline."
         )
-        model_filename: str = Field(description="A list of model filenames to be used for prediction")
         compress_level: int = Field(1, description="Level of compression used in saving EOPatches")
 
     config: Schema
@@ -128,6 +127,7 @@ class BasePredictionPipeline(Pipeline, metaclass=abc.ABCMeta):
 class RegressionPredictionPipeline(BasePredictionPipeline):
     class Schema(BasePredictionPipeline.Schema):
         output_feature_name: str
+        model_filename: str = Field(description="A filename of a regression model to be used for prediction.")
         clip_predictions: Optional[Tuple[float, float]] = Field(
             description="Whether to clip values of predictions to specified interval"
         )
@@ -157,6 +157,7 @@ class ClassificationPredictionPipeline(BasePredictionPipeline):
         output_feature_name: str
         output_probability_feature_name: Optional[str]
 
+        model_filename: str = Field(description="A filename of a classification model to be used for prediction.")
         label_encoder_filename: Optional[str] = Field(
             description=(
                 "Whether the predictions need to be decoded. The label encoder should be in the same model folder."

--- a/eogrow/utils/export.py
+++ b/eogrow/utils/export.py
@@ -4,9 +4,9 @@ Utilities for exporting data
 import logging
 from typing import Any, Dict, List, Optional
 
-import fs.base
 import geopandas as gpd
 import numpy as np
+from fs.base import FS
 
 from sentinelhub import CRS, BBox
 
@@ -19,7 +19,7 @@ def export_grid_stats(
     stats_list: List[Dict[str, object]],
     bbox_list: List[BBox],
     path: str,
-    filesystem: Optional[fs.base.FS] = None,
+    filesystem: Optional[FS] = None,
     names: Optional[List[str]] = None,
 ) -> None:
     """Exports stats per each bounding box (i.e. EOPatch) into a Geopackage file

--- a/eogrow/utils/testing.py
+++ b/eogrow/utils/testing.py
@@ -12,6 +12,7 @@ import pandas as pd
 import rasterio
 import shapely.ops
 from deepdiff import DeepDiff
+from fs.base import FS
 
 from eolearn.core import EOPatch, FeatureType
 
@@ -34,7 +35,7 @@ class ContentTester:
     this utility will let you know which statistics does not match
     """
 
-    def __init__(self, filesystem: fs.base.FS, main_folder: str, decimals: int = 5):
+    def __init__(self, filesystem: FS, main_folder: str, decimals: int = 5):
         """
         :param filesystem: A filesystem containing project data
         :param main_folder: A folder path on the filesystem where results are saved

--- a/tests/test_utils/test_fs.py
+++ b/tests/test_utils/test_fs.py
@@ -29,6 +29,33 @@ def test_local_file(always_copy):
 
 
 @pytest.mark.parametrize("always_copy", [True, False])
+def test_copies_between_local_and_remote(always_copy):
+    """Tests that `copy_to_remote` and `copy_to_local` work correctly."""
+    with TempFS() as filesystem:
+        remote_path = "folder/data.json"
+        with LocalFile(remote_path, mode="w", filesystem=filesystem, always_copy=always_copy) as test_file:
+            if always_copy:
+                assert not filesystem.exists("folder")
+            else:
+                assert filesystem.exists("folder")
+
+            with open(test_file.path, "w") as fp:
+                json.dump({}, fp)
+            if not always_copy:
+                assert filesystem.isfile(remote_path)
+            test_file.copy_to_remote()
+            assert filesystem.isfile(remote_path)
+
+            new_content = {"test": 1}
+            with filesystem.open(remote_path, "w") as fp:
+                json.dump(new_content, fp)
+            test_file.copy_to_local()
+            with open(test_file.path, "r") as fp:
+                result = json.load(fp)
+            assert result == new_content
+
+
+@pytest.mark.parametrize("always_copy", [True, False])
 @pytest.mark.parametrize("workers", [None, 0, 4])
 @pytest.mark.parametrize("walker", [None, Walker(max_depth=1)])
 def test_local_folder(always_copy, workers, walker):

--- a/tests/test_utils/test_fs.py
+++ b/tests/test_utils/test_fs.py
@@ -2,17 +2,20 @@
 Tests for fs_utils module
 """
 import json
+import os
 
 import pytest
 from fs.tempfs import TempFS
+from fs.walk import Walker
 
-from eogrow.utils.fs import LocalFile
+from eogrow.utils.fs import LocalFile, LocalFolder
 
 pytestmark = pytest.mark.fast
 
 
 @pytest.mark.parametrize("always_copy", [True, False])
 def test_local_file(always_copy):
+    """Testing the procedure of saving and loading with LocalFile."""
     with TempFS() as filesystem:
         with LocalFile("path/to/file/data.json", mode="w", filesystem=filesystem, always_copy=always_copy) as test_file:
             with open(test_file.path, "w") as fp:
@@ -23,3 +26,35 @@ def test_local_file(always_copy):
                 result = json.load(fp)
 
         assert result == {}
+
+
+@pytest.mark.parametrize("always_copy", [True, False])
+@pytest.mark.parametrize("workers", [None, 0, 4])
+@pytest.mark.parametrize("walker", [None, Walker(max_depth=1)])
+def test_local_folder(always_copy, workers, walker):
+    """Testing the procedure of saving and loading items with LocalFolder."""
+
+    filenames = ["data1.json", os.path.join("subfolder", "data2.json")]
+
+    with TempFS() as filesystem:
+        with LocalFolder(
+            "path/to/folder/", mode="w", filesystem=filesystem, always_copy=always_copy, workers=workers, walker=walker
+        ) as test_folder:
+            os.mkdir(os.path.join(test_folder.path, "subfolder"))
+
+            for index, filename in enumerate(filenames):
+                file_path = os.path.join(test_folder.path, filename)
+                with open(file_path, "w") as fp:
+                    json.dump({"value": index}, fp)
+
+        with LocalFolder(
+            "path/to/folder/", mode="r", filesystem=filesystem, always_copy=always_copy, workers=workers, walker=walker
+        ) as test_folder:
+            for index, filename in enumerate(filenames):
+                if walker and walker.max_depth <= 1 and filename.startswith("subfolder"):
+                    continue
+
+                file_path = os.path.join(test_folder.path, filename)
+                with open(file_path, "r") as fp:
+                    result = json.load(fp)
+                    assert result == {"value": index}


### PR DESCRIPTION
All these changes were done for a use case of having a prediction pipeline that is using a Tensorflow model.

- Parameter `model_filename` was moved from `BasePredictionPipeline` to its 2 child classes. That is because a Tensorflow model consists of a folder structure with multiple files and it is nicer to handle its name a bit differently.
- Implemented `LocalFolder` utility, improved the overall implementation of `LocalFile`/`LocalFolder`, and added more unit tests.
- Improvements in logs:
  * Figured out how to explicitly prevent the crashes because of emitting logs within emitting logs - by adding a default filter `FilesystemFilter` to the `FilesystemHandler`.
  * Fixed minor issues with config parameters.