### PR TITLE
specialize all type: ignore comments and get rid of some

### DIFF
--- a/eogrow/core/area/custom_grid.py
+++ b/eogrow/core/area/custom_grid.py
@@ -32,7 +32,7 @@ class CustomGridAreaManager(AreaManager):
         )
 
     # TODO: The AreaManager needs to be reworked until this is no longer an issue
-    config: Schema  # type: ignore
+    config: Schema  # type: ignore[assignment]
 
     def get_area_dataframe(self, *, crs: CRS = CRS.WGS84, **_: Any) -> gpd.GeoDataFrame:
         """Provides a single dataframe that defines an AOI

--- a/eogrow/core/pipeline.py
+++ b/eogrow/core/pipeline.py
@@ -279,7 +279,7 @@ class Pipeline(EOGrowObject):
             raise NotImplementedError(
                 "Default implementation of run_procedure method requires implementation of build_workflow method"
             )
-        workflow = self.build_workflow()  # type: ignore
+        workflow = self.build_workflow()  # type: ignore[attr-defined]
         exec_args = self.get_execution_arguments(workflow)
 
         finished, failed, _ = self.run_execution(workflow, exec_args)

--- a/eogrow/pipelines/batch_to_eopatch.py
+++ b/eogrow/pipelines/batch_to_eopatch.py
@@ -65,7 +65,7 @@ class BatchToEOPatchPipeline(Pipeline):
         )
 
         @root_validator
-        def check_something_is_converted(cls, values):  # type: ignore
+        def check_something_is_converted(cls, values):  # type: ignore[no-untyped-def]
             """Check that the pipeline has something to do."""
             params = "userdata_feature_name", "userdata_timestamp_reader", "mapping"
             assert any(

--- a/eogrow/pipelines/download.py
+++ b/eogrow/pipelines/download.py
@@ -131,7 +131,7 @@ class BaseDownloadPipeline(Pipeline, metaclass=abc.ABCMeta):
         for index, bbox in enumerate(bbox_list):
             exec_args[index][download_node] = {"bbox": bbox}
             if hasattr(self.config, "time_period"):
-                exec_args[index][download_node]["time_interval"] = self.config.time_period  # type: ignore
+                exec_args[index][download_node]["time_interval"] = self.config.time_period  # type: ignore[attr-defined]
 
         return exec_args
 

--- a/eogrow/pipelines/prediction.py
+++ b/eogrow/pipelines/prediction.py
@@ -41,7 +41,7 @@ class BasePredictionPipeline(Pipeline, metaclass=abc.ABCMeta):
         )
 
         @validator("prediction_mask_feature_name")
-        def validate_filename(cls, v, values):  # type: ignore
+        def validate_filename(cls, v, values):  # type: ignore[no-untyped-def]
             if values["prediction_mask_folder_key"] is None:
                 assert v is None, "Both `prediction_mask_folder_key` and `prediction_mask_feature_name` must be given."
             return v

--- a/eogrow/pipelines/rasterize.py
+++ b/eogrow/pipelines/rasterize.py
@@ -55,7 +55,7 @@ class VectorColumnSchema(BaseSchema):
     no_data_value: int = Field(0, description="The no_data_value argument to be passed to VectorToRasterTask")
 
     @validator("values_column")
-    def check_value_settings(cls, v, values):  # type: ignore
+    def check_value_settings(cls, v, values):  # type: ignore[no-untyped-def]
         """Ensures that precisely one of `value` and `values_column` is set."""
         assert (v is None) != (values["value"] is None), "Only one of `values_column` and `value` should be given."
         return v

--- a/eogrow/pipelines/sampling.py
+++ b/eogrow/pipelines/sampling.py
@@ -255,7 +255,7 @@ class BlockSamplingPipeline(BaseRandomSamplingPipeline):
         )
 
         @validator("fraction_of_samples", always=True)
-        def validate_sampling_params(cls, fraction, values):  # type: ignore
+        def validate_sampling_params(cls, fraction, values):  # type: ignore[no-untyped-def]
             """Makes sure only one of the sampling parameters has been given"""
             assert (fraction is None) != (
                 values.get("number_of_samples") is None

--- a/eogrow/pipelines/switch_grids.py
+++ b/eogrow/pipelines/switch_grids.py
@@ -37,7 +37,7 @@ class FeatureSchema(BaseSchema):
     )
 
     @root_validator
-    def check_values(cls, values):  # type: ignore
+    def check_values(cls, values):  # type: ignore[no-untyped-def]
         """Multiple different checks that given values make sense."""
         feature = values["feature"]
         feature_type = feature if isinstance(feature, FeatureType) else feature[0]

--- a/eogrow/pipelines/testing.py
+++ b/eogrow/pipelines/testing.py
@@ -16,7 +16,7 @@ from ..tasks.testing import DummyRasterFeatureTask, DummyTimestampFeatureTask
 from ..utils.types import Feature, TimePeriod
 from ..utils.validators import field_validator, parse_time_period
 
-Self = TypeVar("Self", bound=Pipeline)
+Self = TypeVar("Self", bound="TestPipeline")
 LOGGER = logging.getLogger(__name__)
 
 
@@ -37,7 +37,7 @@ class TestPipeline(Pipeline):
 
     @classmethod
     def with_defaults(cls: Type[Self], config: RawConfig) -> Self:
-        config = recursive_config_join(config, cls._DEFAULT_CONFIG_PARAMS)  # type: ignore
+        config = recursive_config_join(config, cls._DEFAULT_CONFIG_PARAMS)  # type: ignore[assignment]
         return cls.from_raw_config(config)
 
     def run_procedure(self) -> Tuple[List, List]:
@@ -155,10 +155,10 @@ class DummyDataPipeline(Pipeline):
         generator = np.random.default_rng(seed=self.config.seed)
         for index, workflow_args in enumerate(exec_args):
             for node in add_feature_nodes:
-                seed = generator.integers(low=0, high=2**32)
+                seed: object = generator.integers(low=0, high=2**32)
 
                 if self._nodes_to_configs_map[node].same_for_all and index > 0:
-                    seed = exec_args[0][node]["seed"]  # type: ignore
+                    seed = exec_args[0][node]["seed"]
 
                 workflow_args[node] = dict(seed=seed)
 

--- a/eogrow/tasks/prediction.py
+++ b/eogrow/tasks/prediction.py
@@ -67,7 +67,7 @@ class BasePredictionTask(EOTask, metaclass=abc.ABCMeta):
         return np.concatenate(all_features, axis=-1)
 
     @property
-    def model(self) -> object:
+    def model(self) -> Any:
         """Implements lazy loading that gets around file-system issues"""
         if self._model is None:
             file_system = get_filesystem(self.model_folder, config=self.sh_config)
@@ -137,7 +137,7 @@ class ClassificationPredictionTask(BasePredictionTask):
         super().__init__(**kwargs)
 
     @property
-    def label_encoder(self) -> object:
+    def label_encoder(self) -> Any:
         """Implements lazy loading that gets around file-system issues"""
         if self._label_encoder is None and self.label_encoder_filename is not None:
             file_system = get_filesystem(self.model_folder, config=self.sh_config)
@@ -150,16 +150,14 @@ class ClassificationPredictionTask(BasePredictionTask):
 
         If specified also adds probability scores and uses a label encoder.
         """
-        predictions = self.apply_predictor(
-            self.model.predict, processed_features, np.zeros((0,), dtype=np.uint8)  # type: ignore
-        )
+        predictions = self.apply_predictor(self.model.predict, processed_features, np.zeros((0,), dtype=np.uint8))
         predictions = predictions[..., np.newaxis]
         if self.label_encoder is not None:
-            predictions = self.label_encoder.inverse_transform(predictions)  # type: ignore
+            predictions = self.label_encoder.inverse_transform(predictions)
         eopatch[self.output_feature] = self.transform_to_feature_form(predictions, mask)
 
         if self.output_probability_feature is not None:
-            probabilities = self.apply_predictor(self.model.predict_proba, processed_features)  # type: ignore
+            probabilities = self.apply_predictor(self.model.predict_proba, processed_features)
             eopatch[self.output_probability_feature] = self.transform_to_feature_form(probabilities, mask)
 
         return eopatch
@@ -184,9 +182,7 @@ class RegressionPredictionTask(BasePredictionTask):
     def add_predictions(self, eopatch: EOPatch, processed_features: np.ndarray, mask: np.ndarray) -> EOPatch:
         """Runs the model prediction on given features and adds them to the eopatch. Must reverse mask beforehand."""
 
-        predictions = self.apply_predictor(
-            self.model.predict, processed_features, np.zeros((0,), dtype=np.float32)  # type: ignore
-        )
+        predictions = self.apply_predictor(self.model.predict, processed_features, np.zeros((0,), dtype=np.float32))
         predictions = predictions[..., np.newaxis]
         if self.clip_predictions is not None:
             predictions = predictions.clip(*self.clip_predictions)

--- a/eogrow/utils/enum.py
+++ b/eogrow/utils/enum.py
@@ -81,7 +81,7 @@ class BaseEOGrowEnum(MultiValueEnum):
 
         script = []
         eval_pixel_script = Template("   if(samples[0].$band_name == $class_id) { return [$colors] }")
-        for class_enum in cls:  # type:ignore[attr-defined]
+        for class_enum in cls:  # type: ignore[attr-defined]
             colors = ", ".join([f"{c}/255" for c in class_enum.rgb_int])
             script.append(eval_pixel_script.substitute(band_name=band_name, class_id=class_enum.id, colors=colors))
 
@@ -90,7 +90,7 @@ class BaseEOGrowEnum(MultiValueEnum):
     @classmethod
     def get_sentinel_hub_legend(cls) -> str:
         items = [
-            {"color": class_enum.color, "label": class_enum.name} for class_enum in cls  # type:ignore[attr-defined]
+            {"color": class_enum.color, "label": class_enum.name} for class_enum in cls  # type: ignore[attr-defined]
         ]
 
         return json.dumps({"type": "discrete", "items": items}, indent=2)

--- a/eogrow/utils/enum.py
+++ b/eogrow/utils/enum.py
@@ -81,7 +81,7 @@ class BaseEOGrowEnum(MultiValueEnum):
 
         script = []
         eval_pixel_script = Template("   if(samples[0].$band_name == $class_id) { return [$colors] }")
-        for class_enum in cls:  # type: ignore
+        for class_enum in cls:  # type:ignore[attr-defined]
             colors = ", ".join([f"{c}/255" for c in class_enum.rgb_int])
             script.append(eval_pixel_script.substitute(band_name=band_name, class_id=class_enum.id, colors=colors))
 
@@ -89,6 +89,8 @@ class BaseEOGrowEnum(MultiValueEnum):
 
     @classmethod
     def get_sentinel_hub_legend(cls) -> str:
-        items = [{"color": class_enum.color, "label": class_enum.name} for class_enum in cls]  # type: ignore
+        items = [
+            {"color": class_enum.color, "label": class_enum.name} for class_enum in cls  # type:ignore[attr-defined]
+        ]
 
         return json.dumps({"type": "discrete", "items": items}, indent=2)

--- a/eogrow/utils/meta.py
+++ b/eogrow/utils/meta.py
@@ -89,7 +89,7 @@ def get_package_versions() -> Dict[str, str]:
 
         dependency_packages = ["eogrow"] + [
             requirement.name
-            for requirement in pkg_resources.working_set.by_key["eogrow"].requires()  # type:ignore[attr-defined]
+            for requirement in pkg_resources.working_set.by_key["eogrow"].requires()  # type: ignore[attr-defined]
         ]
 
         return {name: pkg_resources.get_distribution(name).version for name in dependency_packages}

--- a/eogrow/utils/meta.py
+++ b/eogrow/utils/meta.py
@@ -88,7 +88,8 @@ def get_package_versions() -> Dict[str, str]:
         import pkg_resources
 
         dependency_packages = ["eogrow"] + [
-            requirement.name for requirement in pkg_resources.working_set.by_key["eogrow"].requires()  # type: ignore
+            requirement.name
+            for requirement in pkg_resources.working_set.by_key["eogrow"].requires()  # type:ignore[attr-defined]
         ]
 
         return {name: pkg_resources.get_distribution(name).version for name in dependency_packages}

--- a/eogrow/utils/testing.py
+++ b/eogrow/utils/testing.py
@@ -141,7 +141,7 @@ class ContentTester:
                 finite_values = finite_values.astype(np.uint8)
 
             for operation in [np.min, np.max, np.mean, np.median]:
-                stats.append(round(float(operation(finite_values)), self.decimals))  # type:ignore[operator]
+                stats.append(round(float(operation(finite_values)), self.decimals))  # type: ignore[operator]
 
             stats.extend(map(int, np.histogram(finite_values, bins=8)[0]))
 

--- a/eogrow/utils/testing.py
+++ b/eogrow/utils/testing.py
@@ -141,7 +141,7 @@ class ContentTester:
                 finite_values = finite_values.astype(np.uint8)
 
             for operation in [np.min, np.max, np.mean, np.median]:
-                stats.append(round(float(operation(finite_values)), self.decimals))  # type: ignore
+                stats.append(round(float(operation(finite_values)), self.decimals))  # type:ignore[operator]
 
             stats.extend(map(int, np.histogram(finite_values, bins=8)[0]))
 

--- a/eogrow/utils/validators.py
+++ b/eogrow/utils/validators.py
@@ -113,5 +113,5 @@ def validate_manager(value: dict) -> "ManagerSchema":
     manager_schema = collect_schema(manager_class)
     assert issubclass(
         manager_schema, ManagerSchema
-    ), f"The specified class is not a manager (it's schema does not inherit from {ManagerSchema.__name__}"
+    ), f"The specified class is not a manager (its schema does not inherit from {ManagerSchema.__name__})"
     return manager_schema.parse_obj(value)

--- a/eogrow/utils/validators.py
+++ b/eogrow/utils/validators.py
@@ -34,7 +34,7 @@ def optional_field_validator(
     # In order to propagate the pydantic python magic we need a bit of python magic ourselves
     additional_args = inspect.getfullargspec(validator_fun).args[1:]
 
-    def optional_validator(value, values, config, field):  # type: ignore
+    def optional_validator(value, values, config, field):  # type: ignore[no-untyped-def]
         if value is not None:
             all_kwargs = {"values": values, "config": config, "field": field}
             kwargs = {k: v for k, v in all_kwargs.items() if k in additional_args}
@@ -111,4 +111,7 @@ def validate_manager(value: dict) -> "ManagerSchema":
     assert "manager" in value, "Manager definition has no `manager` field that specifies its class."
     manager_class = import_object(value["manager"])
     manager_schema = collect_schema(manager_class)
-    return manager_schema.parse_obj(value)  # type: ignore
+    assert issubclass(
+        manager_schema, ManagerSchema
+    ), f"The specified class is not a manager (it's schema does not inherit from {ManagerSchema.__name__}"
+    return manager_schema.parse_obj(value)

--- a/eogrow/utils/validators.py
+++ b/eogrow/utils/validators.py
@@ -111,7 +111,4 @@ def validate_manager(value: dict) -> "ManagerSchema":
     assert "manager" in value, "Manager definition has no `manager` field that specifies its class."
     manager_class = import_object(value["manager"])
     manager_schema = collect_schema(manager_class)
-    assert issubclass(
-        manager_schema, ManagerSchema
-    ), f"The specified class is not a manager (its schema does not inherit from {ManagerSchema.__name__})"
-    return manager_schema.parse_obj(value)
+    return manager_schema.parse_obj(value)  # type: ignore[return-value]


### PR DESCRIPTION
When updating another project I remembered that `ŧype: ignore` has an option to specify precisely the type of error you're ignoring. Since this is much better than just ignoring all errors in a line, I re-did all such comments.

In some cases I also manged to avoid the issue by adjusting something else, reducing the number of ignore comments from 20 to 14 :tada: 