### PR TITLE
LocalObject improvements

### DIFF
--- a/eogrow/utils/fs.py
+++ b/eogrow/utils/fs.py
@@ -2,7 +2,7 @@
 Module containing utilities for working with filesystems
 """
 import os
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 import fs
 import fs.copy
@@ -58,6 +58,7 @@ class BaseLocalObject:
             self._filesystem = self._remote_filesystem
             self._local_path = self._remote_path
         else:
+            self._add_tempfs_identifier(temp_fs_kwargs)
             self._filesystem = TempFS(**temp_fs_kwargs)
             self._local_path = fs.path.basename(self._remote_path)
 
@@ -108,6 +109,15 @@ class BaseLocalObject:
         if self._filesystem is not self._remote_filesystem:
             self._ensure_remote_location()
             self._copy_to_remote()
+
+    def _add_tempfs_identifier(self, temp_fs_kwargs: Dict[str, Any]) -> None:
+        """Adds an identifier name that will be used as a suffix of a temporary local folder. This is helpful for
+        debugging purposes."""
+        if "identifier" in temp_fs_kwargs:
+            return
+
+        object_name = fs.path.basename(self._remote_path.rstrip("/")).split(".", 1)[0]
+        temp_fs_kwargs["identifier"] = f"_{self.__class__.__name__}-{object_name}"
 
     def _ensure_remote_location(self) -> None:
         """Makes sure that the remote location exists. If it doesn't then it will try to create the missing folders.

--- a/eogrow/utils/fs.py
+++ b/eogrow/utils/fs.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 import fs
 import fs.copy
 from fs.base import FS
+from fs.errors import ResourceNotFound
 from fs.osfs import OSFS
 from fs.tempfs import TempFS
 from fs.walk import Walker
@@ -35,17 +36,13 @@ class BaseLocalObject:
         """
         :param path: Either a full path to a remote file or a path to remote file which is relative to given filesystem
             object.
-        :type path: str
         :param mode: One of the option `r', 'w', and 'rw`, which specify if a file should be read or written to remote.
             The default is 'r'.
-        :type mode: str
         :param filesystem: A filesystem of the remote. If not given, it will be determined from the path.
-        :type: fs.FS
-        :param config: A config object with which AWS credentials could be used to initialize a remote filesystem object
-        :type config: SHConfig
+        :param config: A config object with which AWS credentials could be used to initialize a remote filesystem
+            object.
         :param always_copy: If True it will always make a local copy to a temporary folder, even if a file is already
             in the local filesystem.
-        :type always_copy: bool
         :param temp_fs_kwargs: Parameters that will be propagated to fs.tempfs.TempFS
         """
         if filesystem is None:
@@ -91,7 +88,7 @@ class BaseLocalObject:
     def close(self) -> None:
         """Close the local copy"""
         if "w" in self._mode:
-            self.copy_to_remote()
+            self.copy_to_remote(raise_missing=False)
 
         if self._filesystem is not self._remote_filesystem:
             self._filesystem.close()
@@ -101,8 +98,13 @@ class BaseLocalObject:
         if self._filesystem is not self._remote_filesystem:
             self._copy_to_local()
 
-    def copy_to_remote(self) -> None:
+    def copy_to_remote(self, raise_missing: bool = True) -> None:
         """Copy from local to remote location"""
+        if not self._filesystem.exists(self._local_path):
+            if raise_missing:
+                raise ResourceNotFound(f"Local resource {self._local_path} doesn't exist")
+            return
+
         if self._filesystem is not self._remote_filesystem:
             self._ensure_remote_location()
             self._copy_to_remote()
@@ -145,9 +147,23 @@ class LocalFolder(BaseLocalObject):
     Check `BaseLocalObject` for more info.
     """
 
-    def __init__(self, *args: Any, walker: Optional[Walker] = None, workers: Optional[int] = None, **kwargs: Any):
+    def __init__(
+        self,
+        path: str,
+        *args: Any,
+        filesystem: Optional[FS] = None,
+        config: Optional[SHConfig] = None,
+        walker: Optional[Walker] = None,
+        workers: Optional[int] = None,
+        **kwargs: Any,
+    ):
         """
+        :param path: Either a full path to a remote folder or a path to remote folder which is relative to given
+            filesystem object.
         :param args: Positional arguments propagated to the base class.
+        :param filesystem: A filesystem of the remote. If not given, it will be determined from the path.
+        :param config: A config object with which AWS credentials could be used to initialize a remote filesystem
+            object.
         :param walker: An instance of `fs.walk.Walker` object used to configure advanced copying parameters. It is
             possible to set max folder depth of copy (default is entire tree), how to handle errors (by default are
             ignored), and what to include or exclude.
@@ -158,7 +174,12 @@ class LocalFolder(BaseLocalObject):
         self.walker = walker or Walker(ignore_errors=True)
         self.workers = 5 * (os.cpu_count() or 1) if workers is None else workers
 
-        super().__init__(*args, **kwargs)
+        if filesystem is None:
+            filesystem, path = get_base_filesystem_and_path(path, config=config)
+        if not path.endswith("/"):
+            path += "/"  # This way fs will treat the path as a folder
+
+        super().__init__(path, *args, filesystem=filesystem, **kwargs)
 
     def _copy_to_local(self) -> None:
         """Copy the folder content from remote to local location."""

--- a/tests/test_utils/test_fs.py
+++ b/tests/test_utils/test_fs.py
@@ -21,6 +21,7 @@ def test_local_file(always_copy):
     with TempFS() as filesystem:
         with LocalFile("path/to/file/data.json", mode="w", filesystem=filesystem, always_copy=always_copy) as test_file:
             assert not os.path.exists(test_file.path)
+
             with open(test_file.path, "w") as fp:
                 json.dump({}, fp)
 
@@ -119,3 +120,16 @@ def test_write_no_data_local_folder(use_absolute_path):
             test_folder.copy_to_remote()
 
         assert filesystem.isdir(relative_remote_path)
+
+
+def test_path_identifier():
+    """Checks that a temporary folder gets correct identifier suffix."""
+    with TempFS() as filesystem:
+        with LocalFile("data.json", mode="w", filesystem=filesystem, always_copy=True) as test_file:
+            assert os.path.dirname(test_file.path).endswith("_LocalFile-data")
+
+        with LocalFile("data.json", mode="w", filesystem=filesystem, always_copy=True, identifier="xxx") as test_file:
+            assert os.path.dirname(test_file.path).endswith("xxx")
+
+        with LocalFolder("my-folder", mode="w", filesystem=filesystem, always_copy=True) as test_folder:
+            assert os.path.dirname(test_folder.path).endswith("_LocalFolder-my-folder")

--- a/tests/test_utils/test_fs.py
+++ b/tests/test_utils/test_fs.py
@@ -4,7 +4,9 @@ Tests for fs_utils module
 import json
 import os
 
+import fs.path
 import pytest
+from fs.errors import ResourceNotFound
 from fs.tempfs import TempFS
 from fs.walk import Walker
 
@@ -18,6 +20,7 @@ def test_local_file(always_copy):
     """Testing the procedure of saving and loading with LocalFile."""
     with TempFS() as filesystem:
         with LocalFile("path/to/file/data.json", mode="w", filesystem=filesystem, always_copy=always_copy) as test_file:
+            assert not os.path.exists(test_file.path)
             with open(test_file.path, "w") as fp:
                 json.dump({}, fp)
 
@@ -26,6 +29,20 @@ def test_local_file(always_copy):
                 result = json.load(fp)
 
         assert result == {}
+
+
+def test_write_no_data_local_file():
+    """Tests a case where no data is written to a local file. An error should only be raised if local file would be
+    explicitly copied to remote."""
+    with TempFS() as filesystem:
+        remote_path = "folder/data.json"
+        with LocalFile(remote_path, mode="w", filesystem=filesystem, always_copy=True) as test_file:
+            test_file.copy_to_remote(raise_missing=False)
+            with pytest.raises(ResourceNotFound):
+                test_file.copy_to_remote(raise_missing=True)
+        # A closure of "with statement" shouldn't raise an error or copy anything
+        assert not filesystem.exists(remote_path)
+        assert not filesystem.exists(fs.path.dirname(remote_path))
 
 
 @pytest.mark.parametrize("always_copy", [True, False])
@@ -67,6 +84,7 @@ def test_local_folder(always_copy, workers, walker):
         with LocalFolder(
             "path/to/folder/", mode="w", filesystem=filesystem, always_copy=always_copy, workers=workers, walker=walker
         ) as test_folder:
+            assert os.path.exists(test_folder.path)
             os.mkdir(os.path.join(test_folder.path, "subfolder"))
 
             for index, filename in enumerate(filenames):
@@ -85,3 +103,19 @@ def test_local_folder(always_copy, workers, walker):
                 with open(file_path, "r") as fp:
                     result = json.load(fp)
                     assert result == {"value": index}
+
+
+@pytest.mark.parametrize("use_absolute_path", [True, False])
+def test_write_no_data_local_folder(use_absolute_path):
+    """Tests a case where no data is written to a local folder."""
+    relative_remote_path = "folder/data-folder"
+    with TempFS() as filesystem:
+        if use_absolute_path:
+            params = dict(path=filesystem.getsyspath(relative_remote_path))
+        else:
+            params = dict(path=relative_remote_path, filesystem=filesystem)
+
+        with LocalFolder(**params, mode="w", always_copy=True) as test_folder:
+            test_folder.copy_to_remote()
+
+        assert filesystem.isdir(relative_remote_path)


### PR DESCRIPTION
Added 2 improvements that were inspired by FD use case:

- Let's say that a local object is opened with write mode, nothing is written in it, and either an error happens or it is just closed. In the previous version an additional error would be raised which was very confusing. In the new version it doesn't do anything which is much more natural behavior.
- A local object is always created in a folder with a unique name. This folder can have suffix that helps users to identify what is in the folder. In this improvement the suffix is constructed with local object class name and a name of the item contained inside.