### PR TITLE
Allows rasterization of temporal/timeless vector features.

### DIFF
--- a/eogrow/pipelines/rasterize.py
+++ b/eogrow/pipelines/rasterize.py
@@ -100,14 +100,14 @@ class RasterizePipeline(Pipeline):
         super().__init__(*args, **kwargs)
 
         self.filename: Optional[str] = None
-        assert len(set([c.output_feature[0].is_temporal() for c in self.config.columns])) == 1, \
-            "All output features have to be either temporal or timeless!"
+
+        if len({c.output_feature[0].is_temporal() for c in self.config.columns}) != 1:
+            raise ValueError("All output features have to be either temporal or timeless!")
 
         if isinstance(self.config.vector_input, str):
             self.filename = self._parse_input_file(self.config.vector_input)
-            feature_type = FeatureType.VECTOR_TIMELESS
-            if self.config.columns[0].output_feature[0].is_temporal():
-                feature_type = FeatureType.VECTOR
+            output_is_temporal = self.config.columns[0].is_temporal()
+            feature_type = FeatureType.VECTOR if output_is_temporal else FeatureType.VECTOR_TIMELESS
             self.vector_feature = feature_type, f"TEMP_{uuid.uuid4().hex}"
         else:
             self.vector_feature = self.config.vector_input

--- a/eogrow/pipelines/rasterize.py
+++ b/eogrow/pipelines/rasterize.py
@@ -100,9 +100,15 @@ class RasterizePipeline(Pipeline):
         super().__init__(*args, **kwargs)
 
         self.filename: Optional[str] = None
+        assert len(set([c.output_feature[0].is_temporal() for c in self.config.columns])) == 1, \
+            "All output features have to be either temporal or timeless!"
+
         if isinstance(self.config.vector_input, str):
             self.filename = self._parse_input_file(self.config.vector_input)
-            self.vector_feature = FeatureType.VECTOR_TIMELESS, f"TEMP_{uuid.uuid4().hex}"
+            feature_type = FeatureType.VECTOR_TIMELESS
+            if self.config.columns[0].output_feature[0].is_temporal():
+                feature_type = FeatureType.VECTOR
+            self.vector_feature = feature_type, f"TEMP_{uuid.uuid4().hex}"
         else:
             self.vector_feature = self.config.vector_input
 

--- a/eogrow/pipelines/rasterize.py
+++ b/eogrow/pipelines/rasterize.py
@@ -106,7 +106,7 @@ class RasterizePipeline(Pipeline):
 
         if isinstance(self.config.vector_input, str):
             self.filename = self._parse_input_file(self.config.vector_input)
-            output_is_temporal = self.config.columns[0].is_temporal()
+            output_is_temporal = self.config.columns[0].output_feature[0].is_temporal()
             feature_type = FeatureType.VECTOR if output_is_temporal else FeatureType.VECTOR_TIMELESS
             self.vector_feature = feature_type, f"TEMP_{uuid.uuid4().hex}"
         else:


### PR DESCRIPTION
Minimal changes that allow rasterizing temporal vector features. If this is merged, then the pipeline can be extended with only the `build_pipeline` method overridden in order to first load existing patches (to have timestamps), and then temporarily add (temporal) vector features that are rasterised. 