### PR TITLE
Fix parameters for pipelines that do not support them

### DIFF
--- a/eogrow/core/schemas.py
+++ b/eogrow/core/schemas.py
@@ -17,7 +17,7 @@ from .base import EOGrowObject
 BaseSchema = EOGrowObject.Schema
 
 
-class ManagerSchema(EOGrowObject.Schema):
+class ManagerSchema(BaseSchema):
     """A basic schema for managers, to be used as a parent class for defining manager schemas"""
 
     manager: Optional[ImportPath] = Field(description="An import path to this specific manager.")
@@ -48,7 +48,7 @@ class LoggingManagerSchema(ManagerSchema):
     )
 
 
-class PipelineSchema(EOGrowObject.Schema):
+class PipelineSchema(BaseSchema):
     """Base schema of the Pipeline class."""
 
     pipeline: Optional[ImportPath] = Field(description="Import path to an implementation of Pipeline class.")

--- a/eogrow/pipelines/download_batch.py
+++ b/eogrow/pipelines/download_batch.py
@@ -2,7 +2,7 @@
 Download pipeline that works with Sentinel Hub batch service
 """
 import logging
-from typing import Any, DefaultDict, Dict, List, Optional, Tuple
+from typing import Any, DefaultDict, Dict, List, Literal, Optional, Tuple
 
 from pydantic import Field
 
@@ -109,6 +109,9 @@ class BatchDownloadPipeline(Pipeline):
                 "existing batch job. If it is not given it will create a new batch job."
             ),
         )
+        patch_list: None = None
+        input_patch_file: None = None
+        skip_existing: Literal[False] = False
 
     config: Schema
     area_manager: BatchAreaManager

--- a/eogrow/pipelines/export_maps.py
+++ b/eogrow/pipelines/export_maps.py
@@ -58,6 +58,7 @@ class ExportMapsPipeline(Pipeline):
                 " With this parameter you force to always make copies."
             ),
         )
+        skip_existing: Literal[False] = False
 
     config: Schema
 

--- a/eogrow/pipelines/merge_samples.py
+++ b/eogrow/pipelines/merge_samples.py
@@ -35,6 +35,7 @@ class MergeSamplesPipeline(Pipeline):
         suffix: str = Field("", description="String to append to array filenames")
         workers: int = Field(1, description="Number of threads used to load data from EOPatches in parallel.")
         use_ray: Literal[False] = Field(False, description="Pipeline does not parallelize properly.")
+        skip_existing: Literal[False] = False
 
     config: Schema
 

--- a/eogrow/pipelines/switch_grids.py
+++ b/eogrow/pipelines/switch_grids.py
@@ -2,7 +2,7 @@
 Pipelines for testing
 """
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 from pydantic import Field, root_validator
 
@@ -95,6 +95,9 @@ class SwitchGridsPipeline(Pipeline):
                 "cause a misalignment. If False, misalignment issues will be ignored."
             ),
         )
+        patch_list: None = None
+        input_patch_file: None = None
+        skip_existing: Literal[False] = False
 
     config: Schema
 

--- a/eogrow/pipelines/training.py
+++ b/eogrow/pipelines/training.py
@@ -3,7 +3,7 @@ Module implementing pipelines for training an ML classifier
 """
 import abc
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 import fs
 import joblib
@@ -62,6 +62,9 @@ class BaseTrainingPipeline(Pipeline, metaclass=abc.ABCMeta):
             default_factory=dict, description="Parameters to be provided to the model"
         )
         model_filename: str
+        patch_list: None = None
+        input_patch_file: None = None
+        skip_existing: Literal[False] = False
 
     config: Schema
 


### PR DESCRIPTION
Some pipelines do not support certain options, such as setting a custom patch list. This makes sure that faulty configurations are rejected at validation time. 

By extension this solves issues with use of -t flag