### PR TITLE
Remove meta info name when filtering Batch2EOPatch

### DIFF
--- a/eogrow/pipelines/batch_to_eopatch.py
+++ b/eogrow/pipelines/batch_to_eopatch.py
@@ -101,7 +101,7 @@ class BatchToEOPatchPipeline(Pipeline):
         features.extend(x.feature for x in self.config.mapping)
 
         if self.config.userdata_feature_name:
-            features.append((FeatureType.META_INFO, self.config.userdata_feature_name))
+            features.append(FeatureType.META_INFO)
 
         if self.config.userdata_timestamp_reader:
             features.append(FeatureType.TIMESTAMP)


### PR DESCRIPTION
As noticed by @batic the filtration currently does not work correctly, because the filtration function cannot figure out which meta info features are present, and therefore if a meta info feature is part of the output, all the patches are marked as incomplete.

This fix shifts the 'wrongness' to the other side. If the meta-feature is not present, but some others are (so a `metainfo.json` exists), it mark this requirement as passing. This shouldn't be too error prone, since all other features must be present as well, and it is unlikely that such a scenario is encountered.

Better fixes can be done once we figure out how to handle meta-info features in general.