### PR TITLE
Minor logging updates

### DIFF
--- a/eogrow/core/logging.py
+++ b/eogrow/core/logging.py
@@ -353,7 +353,7 @@ class LogFileFilter(Filter):
         "s3transfer",
         "matplotlib",
         "fiona",
-        "rasterio._env",
+        "rasterio",
         "graphviz",
         "urllib3",
         "boto3",
@@ -384,7 +384,7 @@ class EOExecutionFilter(Filter):
         "botocore",
         "s3transfer",
         "urllib3",
-        "rasterio._env",
+        "rasterio",
         "numba",
         "fiona.ogrext",
     )

--- a/eogrow/core/logging.py
+++ b/eogrow/core/logging.py
@@ -22,14 +22,36 @@ from ..utils.logging import get_instance_info
 from ..utils.meta import get_package_versions
 from .base import EOGrowObject
 from .config import RawConfig
-from .schemas import LoggingManagerSchema
+from .schemas import ManagerSchema
 from .storage import StorageManager
 
 
 class LoggingManager(EOGrowObject):
     """A class that manages logging specifics"""
 
-    class Schema(LoggingManagerSchema):
+    class Schema(ManagerSchema):
+
+        save_logs: bool = Field(
+            False,
+            description=(
+                "A flag to determine if pipeline logs and reports will be saved to "
+                "logs folder. This includes potential EOExecution reports and logs."
+            ),
+        )
+        include_logs_to_report: bool = Field(
+            False,
+            description=(
+                "If log files should be parsed into an EOExecution report file or just linked. When working "
+                "with larger number of EOPatches the recommended option is False."
+            ),
+        )
+        eoexecution_ignore_packages: Optional[List[str]] = Field(
+            description=(
+                "Names of packages which logs will not be written to EOExecution log files. The default null value "
+                "means that a default list of packages will be used."
+            )
+        )
+
         pipeline_ignore_packages: Optional[List[str]] = Field(
             description=(
                 "Names of packages which logs will not be written to the main pipeline log file. The default null "

--- a/eogrow/core/logging.py
+++ b/eogrow/core/logging.py
@@ -319,9 +319,6 @@ class StdoutFilter(Filter):
 
     def filter(self, record: LogRecord) -> bool:
         """Shows only logs from eo-grow type packages and high-importance logs"""
-        if record.levelno >= logging.WARNING:
-            return True
-
         return any(package_name in record.name for package_name in self.log_packages)
 
 
@@ -334,7 +331,7 @@ class LogFileFilter(Filter):
         "s3transfer",
         "matplotlib",
         "fiona",
-        "rasterio",
+        "rasterio._env",
         "graphviz",
         "urllib3",
         "boto3",
@@ -365,7 +362,7 @@ class EOExecutionFilter(Filter):
         "botocore",
         "s3transfer",
         "urllib3",
-        "rasterio",
+        "rasterio._env",
         "numba",
         "fiona.ogrext",
     )
@@ -380,7 +377,4 @@ class EOExecutionFilter(Filter):
 
     def filter(self, record: LogRecord) -> bool:
         """Ignores logs from certain low-level packages"""
-        if record.levelno >= logging.INFO:
-            return True
-
         return not record.name.startswith(self.ignore_packages)

--- a/eogrow/core/pipeline.py
+++ b/eogrow/core/pipeline.py
@@ -188,10 +188,10 @@ class Pipeline(EOGrowObject):
             workflow,
             exec_args,
             execution_names=eopatch_list,
-            save_logs=self.config.logging.save_logs,
+            save_logs=self.logging_manager.config.save_logs,
             logs_folder=self.logging_manager.get_pipeline_logs_folder(self.current_execution_name),
             filesystem=self.storage.filesystem,
-            logs_filter=EOExecutionFilter(ignore_packages=self.config.logging.eoexecution_ignore_packages),
+            logs_filter=EOExecutionFilter(ignore_packages=self.logging_manager.config.eoexecution_ignore_packages),
             logs_handler_factory=functools.partial(EOExecutionHandler, config=self.sh_config, encoding="utf-8"),
         )
         execution_results = executor.run(**executor_run_params)
@@ -205,8 +205,8 @@ class Pipeline(EOGrowObject):
             len(successful_eopatches) + len(failed_eopatches),
         )
 
-        if self.config.logging.save_logs:
-            executor.make_report(include_logs=self.config.logging.include_logs_to_report)
+        if self.logging_manager.config.save_logs:
+            executor.make_report(include_logs=self.logging_manager.config.include_logs_to_report)
             LOGGER.info("Saved EOExecution report to %s", executor.get_report_path(full_path=True))
 
         return successful_eopatches, failed_eopatches, execution_results

--- a/eogrow/core/schemas.py
+++ b/eogrow/core/schemas.py
@@ -23,31 +23,6 @@ class ManagerSchema(BaseSchema):
     manager: Optional[ImportPath] = Field(description="An import path to this specific manager.")
 
 
-class LoggingManagerSchema(ManagerSchema):
-    """Base schema of a logging manager. Only assumes fields required by the Pipeline class."""
-
-    save_logs: bool = Field(
-        False,
-        description=(
-            "A flag to determine if pipeline logs and reports will be saved to "
-            "logs folder. This includes potential EOExecution reports and logs."
-        ),
-    )
-    include_logs_to_report: bool = Field(
-        False,
-        description=(
-            "If log files should be parsed into an EOExecution report file or just linked. When working "
-            "with larger number of EOPatches the recommended option is False."
-        ),
-    )
-    eoexecution_ignore_packages: Optional[List[str]] = Field(
-        description=(
-            "Names of packages which logs will not be written to EOExecution log files. The default null value "
-            "means that a default list of packages will be used."
-        )
-    )
-
-
 class PipelineSchema(BaseSchema):
     """Base schema of the Pipeline class."""
 
@@ -62,7 +37,7 @@ class PipelineSchema(BaseSchema):
     eopatch: ManagerSchema = Field(description="A schema of an implementation of EOPatchManager class")
     validate_eopatch = field_validator("eopatch", validate_manager, pre=True)
 
-    logging: LoggingManagerSchema = Field(description="A schema of an implementation of LoggingManager class")
+    logging: ManagerSchema = Field(description="A schema of an implementation of LoggingManager class")
     validate_logging = field_validator("logging", validate_manager, pre=True)
 
     workers: int = Field(

--- a/eogrow/utils/testing.py
+++ b/eogrow/utils/testing.py
@@ -181,7 +181,7 @@ class ContentTester:
 
 def check_pipeline_logs(pipeline: Pipeline) -> None:
     """A utility function which checks pipeline logs and makes sure there are no failed executions"""
-    if not pipeline.config.logging.save_logs:
+    if not pipeline.logging_manager.config.save_logs:
         raise ValueError("Pipeline did not save logs, this test would be useless")
 
     logs_folder = pipeline.logging_manager.get_pipeline_logs_folder(pipeline.current_execution_name)


### PR DESCRIPTION
Changes:
- Logging filters now don't automatically accept all logs with level e.g. info or warning above.
- I noticed that we actually don't need `LoggingManagerSchema` because we can access the same parameters in a different way in base `Pipeline` class. This way we can move these logging parameters back to `LoggingManager` which makes them more organized and ready for future improvements.