### PR TITLE
Properly parse dtypes at validation

### DIFF
--- a/eogrow/core/base.py
+++ b/eogrow/core/base.py
@@ -19,6 +19,8 @@ class EOGrowObject:
 
             extra = "forbid"
             validate_all = True
+            allow_mutation = False
+            arbitrary_types_allowed = True
 
     config: Schema
 

--- a/eogrow/pipelines/batch_to_eopatch.py
+++ b/eogrow/pipelines/batch_to_eopatch.py
@@ -3,6 +3,7 @@ Conversion of batch results to EOPatches
 """
 from typing import Any, Dict, List, Optional
 
+import numpy as np
 from pydantic import Field, root_validator
 
 from eolearn.core import (
@@ -23,6 +24,7 @@ from ..core.schemas import BaseSchema
 from ..tasks.batch_to_eopatch import DeleteFilesTask, FixImportedTimeDependentFeatureTask, LoadUserDataTask
 from ..utils.filter import get_patches_with_missing_features
 from ..utils.types import Feature, FeatureSpec
+from ..utils.validators import optional_field_validator, parse_dtype
 
 
 class FeatureMappingSchema(BaseSchema):
@@ -36,7 +38,8 @@ class FeatureMappingSchema(BaseSchema):
     )
     feature: Feature
     multiply_factor: float = Field(1, description="Factor used to multiply feature values with.")
-    dtype: Optional[str] = Field(description="Dtype of the output feature.")
+    dtype: Optional[np.dtype] = Field(description="Dtype of the output feature.")
+    _parse_dtype = optional_field_validator("dtype", parse_dtype, pre=True)
 
 
 class BatchToEOPatchPipeline(Pipeline):

--- a/eogrow/pipelines/download.py
+++ b/eogrow/pipelines/download.py
@@ -30,7 +30,13 @@ from ..core.pipeline import Pipeline
 from ..core.schemas import BaseSchema
 from ..utils.filter import get_patches_with_missing_features
 from ..utils.types import Feature, FeatureSpec, Path, ProcessingType, TimePeriod
-from ..utils.validators import field_validator, parse_data_collection, parse_time_period
+from ..utils.validators import (
+    field_validator,
+    optional_field_validator,
+    parse_data_collection,
+    parse_dtype,
+    parse_time_period,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -53,7 +59,8 @@ class RaySessionActor:
 
 class RescaleSchema(BaseSchema):
     rescale_factor: float = Field(1, description="Amount by which the selected features are multiplied")
-    dtype: Optional[str] = Field(description="The output dtype of data")
+    dtype: Optional[np.dtype] = Field(description="The output dtype of data")
+    _parse_dtype = optional_field_validator("dtype", parse_dtype, pre=True)
     features_to_rescale: List[Feature]
 
 

--- a/eogrow/pipelines/features.py
+++ b/eogrow/pipelines/features.py
@@ -4,6 +4,7 @@ A pipeline to construct features for training/prediction
 import logging
 from typing import Dict, List, Optional, Tuple
 
+import numpy as np
 from pydantic import Field
 
 from eolearn.core import (
@@ -30,7 +31,7 @@ from ..tasks.features import (
 )
 from ..utils.filter import get_patches_with_missing_features
 from ..utils.types import Feature, FeatureSpec, TimePeriod
-from ..utils.validators import field_validator, parse_time_period
+from ..utils.validators import field_validator, optional_field_validator, parse_dtype, parse_time_period
 
 LOGGER = logging.getLogger(__name__)
 
@@ -70,7 +71,8 @@ class FeaturesPipeline(Pipeline):
             ),
         )
 
-        dtype: Optional[str] = Field(description="The dtype under which the concatenated features should be saved")
+        dtype: Optional[np.dtype] = Field(description="The dtype under which the concatenated features should be saved")
+        _parse_dtype = optional_field_validator("dtype", parse_dtype, pre=True)
         output_feature_name: str = Field(description="Name of output data feature encompassing bands and NDIs")
         compress_level: int = Field(1, description="Level of compression used in saving eopatches")
 

--- a/eogrow/pipelines/prediction.py
+++ b/eogrow/pipelines/prediction.py
@@ -4,6 +4,7 @@ Module implementing prediction pipeline
 import abc
 from typing import List, Optional, Tuple
 
+import numpy as np
 from pydantic import Field, validator
 
 from eolearn.core import EONode, EOWorkflow, FeatureType, LoadTask, MergeEOPatchesTask, OverwritePermission, SaveTask
@@ -12,6 +13,7 @@ from ..core.pipeline import Pipeline
 from ..tasks.prediction import ClassificationPredictionTask, RegressionPredictionTask
 from ..utils.filter import get_patches_with_missing_features
 from ..utils.types import Feature, FeatureSpec
+from ..utils.validators import optional_field_validator, parse_dtype
 
 
 class BasePredictionPipeline(Pipeline, metaclass=abc.ABCMeta):
@@ -31,9 +33,10 @@ class BasePredictionPipeline(Pipeline, metaclass=abc.ABCMeta):
         output_folder_key: str = Field(
             description="The storage manager key pointing to the output folder for the prediction pipeline."
         )
-        dtype: Optional[str] = Field(
+        dtype: Optional[np.dtype] = Field(
             description="Casts the result to desired type. Uses predictor output type by default."
         )
+        _parse_dtype = optional_field_validator("dtype", parse_dtype, pre=True)
 
         prediction_mask_folder_key: Optional[str]
         prediction_mask_feature_name: Optional[str] = Field(

--- a/eogrow/pipelines/rasterize.py
+++ b/eogrow/pipelines/rasterize.py
@@ -31,6 +31,7 @@ from ..core.schemas import BaseSchema
 from ..utils.filter import get_patches_with_missing_features
 from ..utils.fs import LocalFile
 from ..utils.types import Feature, FeatureSpec
+from ..utils.validators import field_validator, parse_dtype
 from ..utils.vector import concat_gdf
 
 LOGGER = logging.getLogger(__name__)
@@ -51,7 +52,8 @@ class VectorColumnSchema(BaseSchema):
     polygon_buffer: float = Field(0, description="The size of polygon buffering to be applied before rasterization.")
     resolution: float = Field(description="Rendering resolution in meters.")
     overlap_value: Optional[int] = Field(description="Value to write over the areas where polygons overlap.")
-    dtype: str = Field("int32", description="Numpy dtype of the output feature.")
+    dtype: np.dtype = Field(np.dtype("int32"), description="Numpy dtype of the output feature.")
+    _parse_dtype = field_validator("dtype", parse_dtype, pre=True)
     no_data_value: int = Field(0, description="The no_data_value argument to be passed to VectorToRasterTask")
 
     @validator("values_column")

--- a/eogrow/pipelines/testing.py
+++ b/eogrow/pipelines/testing.py
@@ -14,7 +14,7 @@ from ..core.pipeline import Pipeline
 from ..core.schemas import BaseSchema
 from ..tasks.testing import DummyRasterFeatureTask, DummyTimestampFeatureTask
 from ..utils.types import Feature, TimePeriod
-from ..utils.validators import field_validator, parse_time_period
+from ..utils.validators import field_validator, parse_dtype, parse_time_period
 
 Self = TypeVar("Self", bound="TestPipeline")
 LOGGER = logging.getLogger(__name__)
@@ -72,7 +72,8 @@ class FeatureSchema(BaseSchema):
 class RasterFeatureSchema(FeatureSchema):
     feature: Feature = Field(description="A feature to be processed.")
     shape: Tuple[int, ...] = Field(description="A shape of a feature")
-    dtype: str = Field(description="The output dtype of the feature")
+    dtype: np.dtype = Field(description="The output dtype of the feature")
+    _parse_dtype = field_validator("dtype", parse_dtype, pre=True)
     min_value: int = Field(0, description="All values in the feature will be greater or equal to this value.")
     max_value: int = Field(1, description="All values in the feature will be smaller to this value.")
 

--- a/eogrow/tasks/prediction.py
+++ b/eogrow/tasks/prediction.py
@@ -24,7 +24,7 @@ class BasePredictionTask(EOTask, metaclass=abc.ABCMeta):
         input_features: List[Feature],
         mask_feature: Feature,
         output_feature: Feature,
-        output_dtype: Optional[str],
+        output_dtype: Optional[np.dtype],
         mp_lock: bool,
         sh_config: SHConfig,
     ):

--- a/eogrow/utils/validators.py
+++ b/eogrow/utils/validators.py
@@ -5,6 +5,7 @@ import datetime as dt
 import inspect
 from typing import TYPE_CHECKING, Any, Callable, Tuple
 
+import numpy as np
 from pydantic import validator
 
 from sentinelhub import DataCollection
@@ -104,6 +105,10 @@ def parse_data_collection(value: str) -> DataCollection:
         "Data collection should be a name of an existing DataCollection enum, 'BYOC_<collection_id>', "
         f"or 'BATCH_<collection id>' but name '{value}' was given."
     )
+
+
+def parse_dtype(value: str) -> np.dtype:
+    return np.dtype(value)
 
 
 def validate_manager(value: dict) -> "ManagerSchema":

--- a/tests/test_core/test_schemas.py
+++ b/tests/test_core/test_schemas.py
@@ -4,10 +4,10 @@ Tests for schemas module
 import pytest
 
 from eogrow.core.area import UtmZoneAreaManager
-from eogrow.core.schemas import build_schema_template, build_minimal_template
+from eogrow.core.schemas import build_minimal_template, build_schema_template
 from eogrow.core.storage import StorageManager
-from eogrow.pipelines.mapping import MappingPipeline
 from eogrow.pipelines.export_maps import ExportMapsPipeline
+from eogrow.pipelines.mapping import MappingPipeline
 
 
 @pytest.mark.fast

--- a/tests/test_core/test_schemas.py
+++ b/tests/test_core/test_schemas.py
@@ -4,14 +4,15 @@ Tests for schemas module
 import pytest
 
 from eogrow.core.area import UtmZoneAreaManager
-from eogrow.core.schemas import build_schema_template
+from eogrow.core.schemas import build_schema_template, build_minimal_template
 from eogrow.core.storage import StorageManager
-from eogrow.pipelines.download import DownloadPipeline
+from eogrow.pipelines.mapping import MappingPipeline
 from eogrow.pipelines.export_maps import ExportMapsPipeline
 
 
 @pytest.mark.fast
-@pytest.mark.parametrize("eogrow_object", [UtmZoneAreaManager, DownloadPipeline, ExportMapsPipeline, StorageManager])
-def test_build_schema_template(eogrow_object):
-    template = build_schema_template(eogrow_object.Schema)
+@pytest.mark.parametrize("eogrow_object", [UtmZoneAreaManager, MappingPipeline, ExportMapsPipeline, StorageManager])
+@pytest.mark.parametrize("schema_builder", [build_schema_template, build_minimal_template])
+def test_build_schema_template(eogrow_object, schema_builder):
+    template = schema_builder(eogrow_object.Schema)
     assert isinstance(template, dict)

--- a/tests/test_pipelines/test_batch_to_eopatch.py
+++ b/tests/test_pipelines/test_batch_to_eopatch.py
@@ -29,7 +29,7 @@ def prepare_batch_files(
     width: int,
     height: int,
     num_timestamps: int,
-    dtype: str,
+    dtype: np.dtype,
     add_userdata: bool,
 ):
     transform = rasterio.transform.from_bounds(*tiff_bbox, width=width, height=height)


### PR DESCRIPTION
1. Allow custom types in schemas. It does not change validation of the previous allowed types at all, but for any other types it adds an `isinstance` validation. If a schema has such a type, then open-api templates do not work, but minimal templates dont care.
2. Pipelines now parse dtypes at validation