### PR TITLE
ExportMapPipeline ignores dtype and nodata when merging

### DIFF
--- a/eogrow/pipelines/export_maps.py
+++ b/eogrow/pipelines/export_maps.py
@@ -143,7 +143,14 @@ class ExportMapsPipeline(Pipeline):
             sys_paths = [self.storage.filesystem.getsyspath(path) for path in geotiff_paths]
             sys_map_path = self.storage.filesystem.getsyspath(merged_map_path)
 
-        self._merge_map_function(sys_paths, sys_map_path, cogify=self.config.cogify, delete_input=False)
+        self._merge_map_function(
+            sys_paths,
+            sys_map_path,
+            nodata=self.config.no_data_value,
+            dtype=self.config.map_dtype,
+            cogify=self.config.cogify,
+            delete_input=False,
+        )
 
         if make_local_copies:
             fs.copy.copy_file(temp_fs, map_name, self.storage.filesystem, merged_map_path)

--- a/eogrow/utils/map.py
+++ b/eogrow/utils/map.py
@@ -6,16 +6,23 @@ import os
 import shutil
 import subprocess
 from tempfile import NamedTemporaryFile
-from typing import List, Union
+from typing import List, Literal, Optional, Union
 
 LOGGER = logging.getLogger(__name__)
 
 
-def cogify_inplace(tiff_file: str, blocksize: int = 2048, nodata: Union[None, int, float] = None) -> None:
+
+def cogify_inplace(
+    tiff_file: str,
+    blocksize: int = 2048,
+    nodata: Union[None, int, float] = None,
+    dtype: Optional[Literal["int8", "int16", "uint8", "uint16", "float32"]] = None,
+) -> None:
     """Make the (geotiff) file a cog
     :param tiff_file: .tiff file to cogify
     :param blocksize: block size of tiled COG
     :param nodata: value to be treated as nodata, default value is None
+    :param dtype: output type of the in the resulting tiff, default is None
     """
     temp_file = NamedTemporaryFile()
     temp_file.close()
@@ -29,6 +36,7 @@ def cogify(
     output_file: str,
     blocksize: int = 2048,
     nodata: Union[None, int, float] = None,
+    dtype: Optional[Literal["int8", "int16", "uint8", "uint16", "float32"]] = None,
     overwrite: bool = False,
 ) -> None:
     """Create a cloud optimized version of input file
@@ -37,6 +45,7 @@ def cogify(
     :param output_file: Resulting cog file
     :param blocksize: block size of tiled COG
     :param nodata: value to be treated as nodata, default value is None
+    :param dtype: output type of the in the resulting tiff, default is None
     :param overwrite: If True overwrite the output file if it exists.
     """
     if input_file == output_file:
@@ -75,6 +84,7 @@ def merge_maps(
     *,
     blocksize: int = 2048,
     nodata: Union[None, int, float] = None,
+    dtype: Optional[Literal["int8", "int16", "uint8", "uint16", "float32"]] = None,
     cogify: bool = False,
     delete_input: bool = False,
 ) -> None:
@@ -82,8 +92,9 @@ def merge_maps(
 
     :param input_filename_list: A list of input tiff image filenames
     :param merged_filename: Filename of merged tiff image
-    :param blocksize: block size of tiled COG
-    :param nodata: which values should be treated as nodata in resulting COG, default is None
+    :param blocksize: block size of tiled tiff
+    :param nodata: which values should be treated as nodata in resulting tiff, default is None
+    :param dtype: output type of the in the resulting tiff, default is None
     :param cogify: If True make the final geotiff a COG.
     :param delete_input: If True input images will be deleted at the end
     """
@@ -95,7 +106,13 @@ def merge_maps(
 
 
 def merge_tiffs(
-    input_filename_list: List[str], merged_filename: str, *, overwrite: bool = False, delete_input: bool = False
+    input_filename_list: List[str],
+    merged_filename: str,
+    *,
+    overwrite: bool = False,
+    delete_input: bool = False,
+    nodata: Union[None, int, float] = None,
+    dtype: Optional[Literal["int8", "int16", "uint8", "uint16", "float32"]] = None,
 ) -> None:
     """Performs gdal_merge on a set of given geotiff images
 

--- a/eogrow/utils/map.py
+++ b/eogrow/utils/map.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import subprocess
 from tempfile import NamedTemporaryFile
-from typing import List, Literal, Union
+from typing import List, Literal, Optional
 
 LOGGER = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ GDAL_DTYPE_SETTINGS = {
 def cogify_inplace(
     tiff_file: str,
     blocksize: int = 2048,
-    nodata: Union[None, int, float] = None,
+    nodata: Optional[float] = None,
     dtype: Literal[None, "int8", "int16", "uint8", "uint16", "float32"] = None,
 ) -> None:
     """Make the (geotiff) file a cog
@@ -42,7 +42,7 @@ def cogify(
     input_file: str,
     output_file: str,
     blocksize: int = 2048,
-    nodata: Union[None, int, float] = None,
+    nodata: Optional[float] = None,
     dtype: Literal[None, "int8", "int16", "uint8", "uint16", "float32"] = None,
     overwrite: bool = False,
 ) -> None:
@@ -93,7 +93,7 @@ def merge_maps(
     merged_filename: str,
     *,
     blocksize: int = 2048,
-    nodata: Union[None, int, float] = None,
+    nodata: Optional[float] = None,
     dtype: Literal[None, "int8", "int16", "uint8", "uint16", "float32"] = None,
     cogify: bool = False,
     delete_input: bool = False,
@@ -123,7 +123,7 @@ def merge_tiffs(
     *,
     overwrite: bool = False,
     delete_input: bool = False,
-    nodata: Union[None, int, float] = None,
+    nodata: Optional[float] = None,
     dtype: Literal[None, "int8", "int16", "uint8", "uint16", "float32"] = None,
 ) -> None:
     """Performs gdal_merge on a set of given geotiff images

--- a/eogrow/utils/map.py
+++ b/eogrow/utils/map.py
@@ -34,7 +34,7 @@ def cogify_inplace(
     temp_file = NamedTemporaryFile()
     temp_file.close()
 
-    cogify(tiff_file, temp_file.name, blocksize, nodata=nodata, overwrite=True)
+    cogify(tiff_file, temp_file.name, blocksize, nodata=nodata, dtype=dtype, overwrite=True)
     shutil.move(temp_file.name, tiff_file)
 
 
@@ -75,6 +75,9 @@ def cogify(
     if nodata is not None:
         gdaltranslate_options += f" -a_nodata {nodata}"
 
+    if dtype is not None:
+        gdaltranslate_options += f" {GDAL_DTYPE_SETTINGS[dtype]}"
+
     temp_filename = NamedTemporaryFile()
     temp_filename.close()
     shutil.copyfile(input_file, temp_filename.name)
@@ -111,7 +114,7 @@ def merge_maps(
     )
 
     if cogify:
-        cogify_inplace(merged_filename, blocksize, nodata=nodata)
+        cogify_inplace(merged_filename, blocksize, nodata=nodata, dtype=dtype)
 
 
 def merge_tiffs(

--- a/eogrow/utils/map.py
+++ b/eogrow/utils/map.py
@@ -23,7 +23,7 @@ def cogify_inplace(
     tiff_file: str,
     blocksize: int = 2048,
     nodata: Union[None, int, float] = None,
-    dtype: Optional[Literal["int8", "int16", "uint8", "uint16", "float32"]] = None,
+    dtype: Literal[None, "int8", "int16", "uint8", "uint16", "float32"] = None,
 ) -> None:
     """Make the (geotiff) file a cog
     :param tiff_file: .tiff file to cogify
@@ -43,7 +43,7 @@ def cogify(
     output_file: str,
     blocksize: int = 2048,
     nodata: Union[None, int, float] = None,
-    dtype: Optional[Literal["int8", "int16", "uint8", "uint16", "float32"]] = None,
+    dtype: Literal[None, "int8", "int16", "uint8", "uint16", "float32"] = None,
     overwrite: bool = False,
 ) -> None:
     """Create a cloud optimized version of input file
@@ -94,7 +94,7 @@ def merge_maps(
     *,
     blocksize: int = 2048,
     nodata: Union[None, int, float] = None,
-    dtype: Optional[Literal["int8", "int16", "uint8", "uint16", "float32"]] = None,
+    dtype: Literal[None, "int8", "int16", "uint8", "uint16", "float32"] = None,
     cogify: bool = False,
     delete_input: bool = False,
 ) -> None:
@@ -124,7 +124,7 @@ def merge_tiffs(
     overwrite: bool = False,
     delete_input: bool = False,
     nodata: Union[None, int, float] = None,
-    dtype: Optional[Literal["int8", "int16", "uint8", "uint16", "float32"]] = None,
+    dtype: Literal[None, "int8", "int16", "uint8", "uint16", "float32"] = None,
 ) -> None:
     """Performs gdal_merge on a set of given geotiff images
 

--- a/eogrow/utils/map.py
+++ b/eogrow/utils/map.py
@@ -10,6 +10,13 @@ from typing import List, Literal, Optional, Union
 
 LOGGER = logging.getLogger(__name__)
 
+GDAL_DTYPE_SETTINGS = {
+    "uint8": "-ot Byte",
+    "uint16": "-ot UInt16",
+    "int8": "-ot Byte -co PIXELTYPE=SIGNEDBYTE",
+    "int16": "-ot Int16",
+    "float32": "-ot Float32",
+}
 
 
 def cogify_inplace(

--- a/eogrow/utils/map.py
+++ b/eogrow/utils/map.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import subprocess
 from tempfile import NamedTemporaryFile
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Union
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
In the ExportMapPipeline the tiff exporting task correctly exports the dtype and the no_data part of the EOPatches, but this information doesn't get passed on when the separate tiffs get merged using `gdal_merge.py` and later on in the cogification part.

This MR:
- passes on the `dtype` and the `nodata` value from the pipeline config to the `_merge_map_function`
- converts the python-based `dtype` string to the GDAL-specific combo (workaround for missing 8-bit tiffs)
- passes the `dtype` and `nodata` wherever they can be accepted (`gdal_merge.py` and `gdal_translate`)
- improves the `gdal_merge.py` subprocess string