### PR TITLE
Handling of nonexistent aws_profile

### DIFF
--- a/eogrow/core/storage.py
+++ b/eogrow/core/storage.py
@@ -1,15 +1,13 @@
 """
 This module handles everything regarding storage of the data
 """
-import warnings
 from io import StringIO
 from typing import Dict, List, Optional
 
 import fs
-from botocore.exceptions import ProfileNotFound
-from pydantic import Field
+from fs.base import FS
+from pydantic import BaseSettings, Field
 
-from eolearn.core.exceptions import EOUserWarning
 from eolearn.core.utils.fs import get_aws_credentials, get_filesystem, is_s3_path
 from sentinelhub import SHConfig
 
@@ -21,7 +19,7 @@ from .schemas import ManagerSchema
 class StorageManager(EOGrowObject):
     PRESET_FOLDERS: Dict[str, str] = {"logs": "logs", "input_data": "input-data", "cache": "cache"}
 
-    class Schema(ManagerSchema):
+    class Schema(ManagerSchema, BaseSettings):
         project_folder: str = Field(
             description=(
                 "The root project folder. Can be either local or on AWS S3 Bucket."
@@ -29,10 +27,11 @@ class StorageManager(EOGrowObject):
             ),
         )
         aws_profile: Optional[str] = Field(
+            env="AWS_PROFILE",
             description=(
-                "The AWS profile with credentials needed to access the S3 buckets. In case the profile doesn't exist it"
-                " will show a warning."
-            )
+                "The AWS profile with credentials needed to access the S3 buckets. In case the profile isn't specified"
+                " with a parameter it can be read from an environmental variable."
+            ),
         )
         aws_acl: Optional[AwsAclType] = Field(
             description=(
@@ -44,6 +43,9 @@ class StorageManager(EOGrowObject):
             default_factory=dict, description="A flat key: value store mapping each key to a path in the project."
         )
 
+        class Config(ManagerSchema.Config):
+            case_sensitive = True
+
     config: Schema
 
     def __init__(self, config: Schema):
@@ -54,12 +56,7 @@ class StorageManager(EOGrowObject):
                 self.config.structure[folder_key] = folder_path
 
         self.sh_config = self._prepare_sh_config()
-
-        fs_kwargs: Dict[str, str] = {}
-        if is_s3_path(self.config.project_folder) and self.config.aws_acl:
-            fs_kwargs["acl"] = self.config.aws_acl
-
-        self.filesystem = get_filesystem(self.config.project_folder, create=True, config=self.sh_config, **fs_kwargs)
+        self.filesystem = self._prepare_filesystem()
 
     def _prepare_sh_config(self) -> SHConfig:
         """Prepares an instance of `SHConfig` containing AWS credentials. In case given AWS profile doesn't exist it
@@ -67,12 +64,17 @@ class StorageManager(EOGrowObject):
         sh_config = SHConfig(hide_credentials=True)
 
         if self.is_on_aws() and self.config.aws_profile:
-            try:
-                sh_config = get_aws_credentials(aws_profile=self.config.aws_profile, config=sh_config)
-            except ProfileNotFound as exception:
-                warnings.warn(str(exception), category=EOUserWarning)
+            sh_config = get_aws_credentials(aws_profile=self.config.aws_profile, config=sh_config)
 
         return sh_config
+
+    def _prepare_filesystem(self) -> FS:
+        """Prepares the main instance of filesystem object which contains all additional configuration parameters."""
+        fs_kwargs: Dict[str, str] = {}
+        if is_s3_path(self.config.project_folder) and self.config.aws_acl:
+            fs_kwargs["acl"] = self.config.aws_acl
+
+        return get_filesystem(self.config.project_folder, create=True, config=self.sh_config, **fs_kwargs)
 
     def get_folder(self, key: str, full_path: bool = False) -> str:
         """Returns the path  associated with a key in the structure config."""

--- a/eogrow/core/storage.py
+++ b/eogrow/core/storage.py
@@ -45,6 +45,7 @@ class StorageManager(EOGrowObject):
 
         class Config(ManagerSchema.Config):
             case_sensitive = True
+            env_prefix = "eogrow_"
 
     config: Schema
 

--- a/eogrow/utils/general.py
+++ b/eogrow/utils/general.py
@@ -4,7 +4,7 @@ A module containing general utilities that haven't been sorted in any other modu
 import datetime as dt
 import math
 from enum import Enum
-from typing import Tuple
+from typing import Tuple, Union
 
 import numpy as np
 from aenum import MultiValueEnum
@@ -13,8 +13,11 @@ from sentinelhub import BBox, DataCollection
 from sentinelhub.data_collections import DataCollectionDefinition
 
 
-def jsonify(param: object) -> str:
+def jsonify(param: object) -> Union[str, list]:
     """Transforms an object into a normal string."""
+    if isinstance(param, set):
+        return list(param)
+
     if isinstance(param, (dt.datetime, dt.date)):
         return param.isoformat()
 

--- a/tests/test_config_files/other/aws_storage_test.json
+++ b/tests/test_config_files/other/aws_storage_test.json
@@ -1,12 +1,9 @@
 {
-  "**global_config": "${config_path}/../global_config.json",
-  "storage": {
-    "manager": "eogrow.core.storage.StorageManager",
-    "project_folder": "s3://eogrow-test-storage/test",
-    "aws_profile": "test-storage-profile",
-    "structure": {
-      "batch": "tiffs",
-      "eopatches": "eopatches"
-    }
+  "manager": "eogrow.core.storage.StorageManager",
+  "project_folder": "s3://eogrow-test-storage/test",
+  "aws_profile": null,
+  "structure": {
+    "batch": "tiffs",
+    "eopatches": "eopatches"
   }
 }

--- a/tests/test_core/test_storage.py
+++ b/tests/test_core/test_storage.py
@@ -72,7 +72,12 @@ def test_get_custom_folder(local_storage_manager: StorageManager, project_folder
 @pytest.mark.parametrize("env_profile", [None, "", "nonexistent-env-profile"])
 def test_aws_profile(aws_storage_config: RawConfig, config_profile: Optional[str], env_profile: Optional[str]):
     """Checks different combinations of profile being set with a config parameter and environmental variable. Checks
-    also that config parameter takes priority over environmental variable."""
+    also that config parameter takes priority over environmental variable.
+
+    In the first step of this test, we add given profile name parameters into the config dictionary and into the
+    dictionary of environmental variables. Note that if profile name is `None`, we instead remove the parameter from a
+    dictionary altogether.
+    """
 
     for parameter_key, parameter_value, config_dict in [
         ("aws_profile", config_profile, aws_storage_config),

--- a/tests/test_core/test_storage.py
+++ b/tests/test_core/test_storage.py
@@ -83,15 +83,19 @@ def test_aws_profile(aws_storage_config: RawConfig, config_profile: Optional[str
         elif parameter_key in config_dict:
             del config_dict[parameter_key]
 
-    expected_profile = config_profile if config_profile is not None else env_profile
-    if expected_profile:
-        with pytest.raises(ProfileNotFound) as exception_info:
-            StorageManager.from_raw_config(aws_storage_config)
+    try:
+        expected_profile = config_profile if config_profile is not None else env_profile
+        if expected_profile:
+            with pytest.raises(ProfileNotFound) as exception_info:
+                StorageManager.from_raw_config(aws_storage_config)
 
-        assert str(exception_info.value) == f"The config profile ({expected_profile}) could not be found"
-    else:
-        storage = StorageManager.from_raw_config(aws_storage_config)
-        assert storage.config.aws_profile == expected_profile
+            assert str(exception_info.value) == f"The config profile ({expected_profile}) could not be found"
+        else:
+            storage = StorageManager.from_raw_config(aws_storage_config)
+            assert storage.config.aws_profile == expected_profile
+    finally:
+        if "AWS_PROFILE" in os.environ:
+            del os.environ["AWS_PROFILE"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils/test_general.py
+++ b/tests/test_utils/test_general.py
@@ -24,14 +24,14 @@ ORIGINAL_CONFIG = {
     "feature_types": (FeatureType.DATA, FeatureType.BBOX),
     "multi_value_enum": MyEnum.NO_DATA,
     "timestamp": dt.datetime(year=2021, month=9, day=30),
-    "collection": DataCollection.SENTINEL2_L1C,
+    "collection_set": {DataCollection.SENTINEL2_L1C},
     "collection_def": DataCollection.SENTINEL2_L1C.value,
 }
 SERIALIZED_CONFIG = {
     "feature_types": ["data", "bbox"],
     "multi_value_enum": "no data",
     "timestamp": "2021-09-30T00:00:00",
-    "collection": "SENTINEL2_L1C",
+    "collection_set": ["SENTINEL2_L1C"],
     "collection_def": "SENTINEL2_L1C",
 }
 


### PR DESCRIPTION
This PR changes that in case given AWS profile doesn't exist a warning is shown instead of an error. It also adds a test that checks this.

The reason for this is purely practical - if you run a pipeline on AWS instance with a role that already allows accessing S3 buckets you don't need AWS profiles. But if you run a pipeline locally then you need to specify `aws_profile` in order to access S3 buckets. So to avoid constantly changing `aws_profile` parameter it seems easier to just give a warning instead of an error. Although I'm not 100% sure if this really justifies this change. :thinking: 