### PR TITLE
A few docs-related improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,7 @@ coverage.xml
 
 # Sphinx documentation
 docs/build/
-docs/source/reference/*.rst
+docs/source/reference/
 
 # PyBuilder
 target/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,4 +18,4 @@ help:
 %: Makefile
 	rm -rf ./build/
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-	rm -r source/markdowns
+	rm -r source/markdowns source/reference

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -88,7 +88,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -255,12 +255,13 @@ process_readme()
 
 # Auto-generate documentation pages
 current_dir = os.path.abspath(os.path.dirname(__file__))
-target_dir = os.path.join(current_dir, "reference")
+reference_dir = os.path.join(current_dir, "reference")
 module = os.path.join(current_dir, "..", "..", "eogrow")
-os.makedirs(target_dir, exist_ok=True)
 
 APIDOC_EXCLUDE = [os.path.join(module, "cli.py")]
 APIDOC_OPTIONS = ["--module-first", "--separate", "--no-toc", "--templatedir", os.path.join(current_dir, "_templates")]
+
+shutil.rmtree(reference_dir, ignore_errors=True)
 
 
 def run_apidoc(_):
@@ -268,7 +269,7 @@ def run_apidoc(_):
 
     sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
-    main(["-e", "-o", target_dir, module, *APIDOC_EXCLUDE, *APIDOC_OPTIONS])
+    main(["-e", "-o", reference_dir, module, *APIDOC_EXCLUDE, *APIDOC_OPTIONS])
 
 
 def setup(app):

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,12 @@ setup(
     long_description=get_long_description(),
     long_description_content_type="text/markdown",
     url="https://github.com/sentinel-hub/eo-grow",
+    project_urls={
+        "Documentation": "https://eo-grow.readthedocs.io",
+        "Source Code": "https://github.com/sentinel-hub/eo-grow",
+        "Bug Tracker": "https://github.com/sentinel-hub/eo-grow/issues",
+        "Forum": "https://forum.sentinel-hub.com",
+    },
     author="Sinergise EO research team",
     author_email="eoresearch@sinergise.com",
     license="MIT",


### PR DESCRIPTION
Same things as in sentinelhub-py, except that here we don't yet need `custom_reference` folder.