### PR TITLE
Add raster_shape param to rasterize pipeline

### DIFF
--- a/eogrow/pipelines/download.py
+++ b/eogrow/pipelines/download.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import ray
-from pydantic import Field, root_validator
+from pydantic import Field
 
 from eolearn.core import EONode, EOWorkflow, FeatureType, OverwritePermission, SaveTask
 from eolearn.features import LinearFunctionTask
@@ -29,8 +29,9 @@ from sentinelhub.download import SessionSharing, collect_shared_session
 from ..core.pipeline import Pipeline
 from ..core.schemas import BaseSchema
 from ..utils.filter import get_patches_with_missing_features
-from ..utils.types import Feature, FeatureSpec, Path, ProcessingType, RawSchemaDict, TimePeriod
+from ..utils.types import Feature, FeatureSpec, Path, ProcessingType, TimePeriod
 from ..utils.validators import (
+    ensure_exactly_one_defined,
     field_validator,
     optional_field_validator,
     parse_data_collection,
@@ -216,17 +217,7 @@ class CommonDownloadFields(BaseSchema):
         description="A type of downsampling and upsampling used by Sentinel Hub service. Default is NEAREST"
     )
 
-    @root_validator
-    def check_resolution_and_size(cls, values: RawSchemaDict) -> RawSchemaDict:
-        """Check that exactly one of the parameters resolution and size is defined."""
-        is_resolution_defined = values.get("resolution") is not None
-        is_size_defined = values.get("size") is not None
-
-        assert (
-            is_resolution_defined != is_size_defined
-        ), "Exactly one of the parameters resolution and size has to be given."
-
-        return values
+    _check_resolution_and_size = ensure_exactly_one_defined("resolution", "size")
 
 
 class TimeDependantFields(BaseSchema):

--- a/eogrow/pipelines/sampling.py
+++ b/eogrow/pipelines/sampling.py
@@ -5,16 +5,18 @@ import abc
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
-from pydantic import Field, root_validator
+from pydantic import Field
 
 from eolearn.core import EONode, EOWorkflow, FeatureType, LoadTask, MergeEOPatchesTask, OverwritePermission, SaveTask
 from eolearn.geometry import MorphologicalOperations, MorphologicalStructFactory
 from eolearn.ml_tools import BlockSamplingTask, FractionSamplingTask, GridSamplingTask
 
+from eogrow.utils.validators import ensure_exactly_one_defined
+
 from ..core.pipeline import Pipeline
 from ..tasks.common import ClassFilterTask
 from ..utils.filter import get_patches_with_missing_features
-from ..utils.types import Feature, FeatureSpec, RawSchemaDict
+from ..utils.types import Feature, FeatureSpec
 
 
 class BaseSamplingPipeline(Pipeline, metaclass=abc.ABCMeta):
@@ -254,17 +256,7 @@ class BlockSamplingPipeline(BaseRandomSamplingPipeline):
             )
         )
 
-        @root_validator
-        def validate_sampling_params(cls, values: RawSchemaDict) -> RawSchemaDict:
-            """Makes sure only one of the sampling parameters has been given."""
-            is_fraction_defined = values.get("fraction_of_samples") is not None
-            is_number_defined = values.get("number_of_samples") is not None
-
-            assert (
-                is_fraction_defined != is_number_defined
-            ), "Exactly one of the parameters fraction_of_samples and number_of_samples should be given."
-
-            return values
+        _check_fraction_number = ensure_exactly_one_defined("fraction_of_samples", "number_of_samples")
 
     config: Schema
 

--- a/tests/test_config_files/rasterize/rasterize_pipeline.json
+++ b/tests/test_config_files/rasterize/rasterize_pipeline.json
@@ -13,7 +13,7 @@
     {
       "values_column": "POLYGON_ID",
       "output_feature": ["mask_timeless", "POLYGON_ID"],
-      "resolution": 10
+      "raster_shape": [121, 264]
     }
   ],
   "preprocess_dataset": {}


### PR DESCRIPTION
Exposes another parameter of the rasterization task.

I also noticed a common pattern of validators, which i managed to extract into `ensure_exactly_one_defined` function. It was tested locally.