### PR TITLE
Better DataCollection parsing

### DIFF
--- a/eogrow/pipelines/download.py
+++ b/eogrow/pipelines/download.py
@@ -195,7 +195,12 @@ class BaseDownloadPipeline(Pipeline, metaclass=abc.ABCMeta):
 
 
 class CommonDownloadFields(BaseSchema):
-    data_collection: DataCollection = Field(description="Data collection from which data will be downloaded.")
+    data_collection: DataCollection = Field(
+        description=(
+            "Data collection from which data will be downloaded. See `utils.validators.parse_data_collection` for more"
+            " info on input options."
+        )
+    )
     _validate_data_collection = field_validator("data_collection", parse_data_collection, pre=True)
 
     resolution: Optional[float] = Field(

--- a/eogrow/pipelines/download_batch.py
+++ b/eogrow/pipelines/download_batch.py
@@ -34,7 +34,12 @@ LOGGER = logging.getLogger(__name__)
 class InputDataSchema(BaseSchema):
     """Parameter structure for a single data collection used in a batch request."""
 
-    data_collection: DataCollection = Field(description="Data collection from which data will be downloaded.")
+    data_collection: DataCollection = Field(
+        description=(
+            "Data collection from which data will be downloaded. See `utils.validators.parse_data_collection` for more"
+            " info on input options."
+        )
+    )
     _validate_data_collection = field_validator("data_collection", parse_data_collection, pre=True)
 
     time_period: Optional[TimePeriod]

--- a/tests/test_config_files/download_and_batch/download_season.json
+++ b/tests/test_config_files/download_and_batch/download_season.json
@@ -2,7 +2,19 @@
   "pipeline": "eogrow.pipelines.download.DownloadPipeline",
   "**global_config": "${config_path}/../global_config.json",
   "output_folder_key": "temp",
-  "data_collection": "SENTINEL2_L1C",
+  "data_collection": {
+    "name": "SENTINEL2_L1C_CUSTOM",
+    "api_id": "sentinel-2-l1c",
+    "catalog_id": "sentinel-2-l1c",
+    "service_url": "https://services.sentinel-hub.com",
+    "collection_type": "Sentinel-2",
+    "bands": "SENTINEL2_L1C",
+    "metabands": [
+      {"name": "CLM", "units": ["DN"], "output_types": ["uint8"]},
+      {"name": "dataMask", "units": ["DN"], "output_types": ["bool"]}
+    ],
+    "has_cloud_coverage": true
+  },
   "time_period": ["season", 2018],
   "bands_feature_name": "BANDS-S2-L1C",
   "resolution": 10,

--- a/tests/test_utils/test_validators.py
+++ b/tests/test_utils/test_validators.py
@@ -10,6 +10,7 @@ import pytest
 from pydantic import ValidationError
 
 from sentinelhub import DataCollection
+from sentinelhub.data_collections_bands import Band, MetaBands, Unit
 
 from eogrow.core.schemas import BaseSchema, ManagerSchema
 from eogrow.utils.types import RawSchemaDict
@@ -127,27 +128,6 @@ def test_parse_time_period(time_period, year, expected_start_date, expected_end_
     assert end_date.isoformat() == expected_end_date
 
 
-@pytest.mark.parametrize(
-    "collection_input, is_byoc, is_batch",
-    [
-        ("SENTINEL2_L2A", False, False),
-        ("SENTINEL3_SLSTR", False, False),
-        ("BYOC_blabla", True, False),
-        ("BATCH_blabla", False, True),
-    ],
-)
-def test_parse_colletion(collection_input: str, is_byoc: bool, is_batch: bool):
-    class CollectionSchema(BaseSchema):
-        collection: DataCollection
-        _parse_collection = field_validator("collection", parse_data_collection, pre=True)
-
-    schema = CollectionSchema(collection=collection_input)
-    assert isinstance(schema.collection, DataCollection)
-    assert schema.collection.name in collection_input
-    assert schema.collection.is_byoc == is_byoc
-    assert schema.collection.is_batch == is_batch
-
-
 @pytest.mark.parametrize("dtype_input", ["uint8", "float32", np.uint8, np.dtype("int16")])
 def test_parse_dtype(dtype_input: Union[str, type, np.dtype]):
     class DtypeSchema(BaseSchema):
@@ -198,3 +178,45 @@ def test_validate_manager(manager_input: RawSchemaDict, succeeds: bool):
 
     with nullcontext() if succeeds else pytest.raises(ValidationError):
         SchemaWithManager(manager=manager_input)
+
+
+@pytest.mark.parametrize(
+    "collection_input, is_byoc, is_batch",
+    [
+        ("SENTINEL2_L2A", False, False),
+        ("SENTINEL3_SLSTR", False, False),
+        ("BYOC_blabla", True, False),
+        ("BATCH_blabla", False, True),
+    ],
+)
+def test_parse_colletion_from_string(collection_input: str, is_byoc: bool, is_batch: bool):
+    class CollectionSchema(BaseSchema):
+        collection: DataCollection
+        _parse_collection = field_validator("collection", parse_data_collection, pre=True)
+
+    schema = CollectionSchema(collection=collection_input)
+    assert isinstance(schema.collection, DataCollection)
+    assert schema.collection.name in collection_input
+    assert schema.collection.is_byoc == is_byoc
+    assert schema.collection.is_batch == is_batch
+
+
+def test_parse_colletion_from_dict():
+    class CollectionSchema(BaseSchema):
+        collection: DataCollection
+        _parse_collection = field_validator("collection", parse_data_collection, pre=True)
+
+    raw_schema = {
+        "name": "test",
+        "api_id": "sentinel-2-l1c",
+        "wfs_id": "DSS1",
+        "service_url": "blabla",
+        "processing_level": "L1C",
+        "bands": [{"name": "Band1", "units": ["DN"], "output_types": ["float32"]}],
+        "metabands": "SENTINEL2_L1C",
+    }
+    schema = CollectionSchema(collection=raw_schema)
+    assert isinstance(schema.collection, DataCollection)
+    assert schema.collection.bands == (Band("Band1", (Unit.DN,), (np.float32,)))
+    assert schema.collection.metabands is MetaBands.SENTINEL2_L1C
+    assert schema.collection.is_batch == False

--- a/tests/test_utils/test_validators.py
+++ b/tests/test_utils/test_validators.py
@@ -189,7 +189,7 @@ def test_validate_manager(manager_input: RawSchemaDict, succeeds: bool):
         ("BATCH_blabla", False, True),
     ],
 )
-def test_parse_colletion_from_string(collection_input: str, is_byoc: bool, is_batch: bool):
+def test_parse_collection_from_string(collection_input: str, is_byoc: bool, is_batch: bool):
     class CollectionSchema(BaseSchema):
         collection: DataCollection
         _parse_collection = field_validator("collection", parse_data_collection, pre=True)
@@ -201,7 +201,7 @@ def test_parse_colletion_from_string(collection_input: str, is_byoc: bool, is_ba
     assert schema.collection.is_batch == is_batch
 
 
-def test_parse_colletion_from_dict():
+def test_parse_collection_from_dict():
     class CollectionSchema(BaseSchema):
         collection: DataCollection
         _parse_collection = field_validator("collection", parse_data_collection, pre=True)

--- a/tests/test_utils/test_validators.py
+++ b/tests/test_utils/test_validators.py
@@ -215,8 +215,22 @@ def test_parse_colletion_from_dict():
         "bands": [{"name": "Band1", "units": ["DN"], "output_types": ["float32"]}],
         "metabands": "SENTINEL2_L1C",
     }
-    schema = CollectionSchema(collection=raw_schema)
-    assert isinstance(schema.collection, DataCollection)
-    assert schema.collection.bands == (Band("Band1", (Unit.DN,), (np.float32,)))
-    assert schema.collection.metabands is MetaBands.SENTINEL2_L1C
-    assert schema.collection.is_batch == False
+    collection = CollectionSchema(collection=raw_schema).collection
+    assert isinstance(collection, DataCollection)
+    assert collection.bands == (Band("Band1", (Unit.DN,), (np.dtype("float32"),)),)
+    assert collection.metabands is MetaBands.SENTINEL2_L1C
+    assert collection.is_byoc is False
+
+    raw_schema = {
+        "name": "BYOC_test",
+        "api_id": "override",
+        "bands": [
+            {"name": "Band1", "units": ["DN"], "output_types": ["float32"]},
+            {"name": "Band2", "units": ["REFLECTANCE"], "output_types": ["bool"]},
+        ],
+    }
+    collection = CollectionSchema(collection=raw_schema).collection
+    assert isinstance(collection, DataCollection)
+    assert collection.catalog_id == "byoc-test"
+    assert collection.bands == (Band("Band1", (Unit.DN,), (np.float32,)), Band("Band2", (Unit.REFLECTANCE,), (bool,)))
+    assert collection.is_byoc is True


### PR DESCRIPTION
Previously data collections were specified by a string, which was either a name of an existing collection, or used as a byoc/batch ID. This caused issues when using custom collections, and using BYOC collections without evalscripts was difficult (couldn't specify bands). Also default values of such fields had to be strings, and when working in python (notebooks) one couldn't just pass in a collection.

Now one can:
- provide a `DataCollection` (for direct python work and defaults).
- provide a name of an existing collection
- provide a (prefixed) ID of a BYOC/BATCH collection for basic definition
- provide a detailed definition via `DataCollectionSchema` (which supports BYOC/BATCH automation via prefixes)