### PR TITLE
Improve Schema docbuilding

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,6 +62,7 @@ extensions = [
 
 # autodoc_pydantic settings
 autodoc_pydantic_settings_show_json = False
+autodoc_pydantic_model_show_config_member = False
 autodoc_pydantic_settings_show_config_summary = False
 
 # Incude typehints in descriptions

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,6 +57,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.githubpages",
     "m2r2",
+    "sphinxcontrib.autodoc_pydantic",
 ]
 
 # Incude typehints in descriptions

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -61,9 +61,8 @@ extensions = [
 ]
 
 # autodoc_pydantic settings
-autodoc_pydantic_settings_show_json = False
-autodoc_pydantic_model_show_config_member = False
-autodoc_pydantic_settings_show_config_summary = False
+autodoc_pydantic_show_json = False
+autodoc_pydantic_model_show_config = False
 
 # Incude typehints in descriptions
 autodoc_typehints = "description"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,6 +60,11 @@ extensions = [
     "sphinxcontrib.autodoc_pydantic",
 ]
 
+# autodoc_pydantic settings
+autodoc_pydantic_settings_show_json = False
+autodoc_pydantic_settings_show_config_summary = False
+autodoc_pydantic_settings_summary_list_order = "bysource"
+
 # Incude typehints in descriptions
 autodoc_typehints = "description"
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,9 +64,15 @@ extensions = [
 autodoc_pydantic_model_show_json = False
 autodoc_pydantic_model_show_config = False
 autodoc_pydantic_model_show_config_summary = False
+autodoc_pydantic_model_show_validators_summary = False
+autodoc_pydantic_model_summary_list_order = "bysource"
+autodoc_pydantic_model_member_order = "bysource"
 autodoc_pydantic_settings_show_json = False
 autodoc_pydantic_settings_show_config = False
 autodoc_pydantic_settings_show_config_summary = False
+autodoc_pydantic_settings_show_validators_summary = False
+autodoc_pydantic_settings_summary_list_order = "bysource"
+autodoc_pydantic_settings_member_order = "bysource"
 
 # Incude typehints in descriptions
 autodoc_typehints = "description"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,8 +63,10 @@ extensions = [
 # autodoc_pydantic settings
 autodoc_pydantic_model_show_json = False
 autodoc_pydantic_model_show_config = False
+autodoc_pydantic_model_show_config_summary = False
 autodoc_pydantic_settings_show_json = False
 autodoc_pydantic_settings_show_config = False
+autodoc_pydantic_settings_show_config_summary = False
 
 # Incude typehints in descriptions
 autodoc_typehints = "description"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,7 +63,6 @@ extensions = [
 # autodoc_pydantic settings
 autodoc_pydantic_settings_show_json = False
 autodoc_pydantic_settings_show_config_summary = False
-autodoc_pydantic_settings_summary_list_order = "bysource"
 
 # Incude typehints in descriptions
 autodoc_typehints = "description"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,11 +64,11 @@ extensions = [
 autodoc_pydantic_model_show_json = False
 autodoc_pydantic_model_show_config = False
 autodoc_pydantic_model_show_config_summary = False
-autodoc_pydantic_model_show_validators_summary = False
+autodoc_pydantic_model_show_validator_summary = False
 autodoc_pydantic_settings_show_json = False
 autodoc_pydantic_settings_show_config = False
 autodoc_pydantic_settings_show_config_summary = False
-autodoc_pydantic_settings_show_validators_summary = False
+autodoc_pydantic_settings_show_validator_summary = False
 
 # Incude typehints in descriptions
 autodoc_typehints = "description"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,14 +65,10 @@ autodoc_pydantic_model_show_json = False
 autodoc_pydantic_model_show_config = False
 autodoc_pydantic_model_show_config_summary = False
 autodoc_pydantic_model_show_validators_summary = False
-autodoc_pydantic_model_summary_list_order = "bysource"
-autodoc_pydantic_model_member_order = "bysource"
 autodoc_pydantic_settings_show_json = False
 autodoc_pydantic_settings_show_config = False
 autodoc_pydantic_settings_show_config_summary = False
 autodoc_pydantic_settings_show_validators_summary = False
-autodoc_pydantic_settings_summary_list_order = "bysource"
-autodoc_pydantic_settings_member_order = "bysource"
 
 # Incude typehints in descriptions
 autodoc_typehints = "description"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -61,8 +61,10 @@ extensions = [
 ]
 
 # autodoc_pydantic settings
-autodoc_pydantic_show_json = False
+autodoc_pydantic_model_show_json = False
 autodoc_pydantic_model_show_config = False
+autodoc_pydantic_settings_show_json = False
+autodoc_pydantic_settings_show_config = False
 
 # Incude typehints in descriptions
 autodoc_typehints = "description"

--- a/eogrow/pipelines/download_batch.py
+++ b/eogrow/pipelines/download_batch.py
@@ -78,7 +78,7 @@ class BatchDownloadPipeline(Pipeline):
         batch_output_kwargs: dict = Field(
             default_factory=dict,
             description=(
-                "Any other arguments to be added to a dictionary of parameters. Passed as **kwargs to the `output`"
+                "Any other arguments to be added to a dictionary of parameters. Passed as `**kwargs` to the `output`"
                 " method of `SentinelHubBatch` during the creation process."
             ),
         )

--- a/eogrow/utils/validators.py
+++ b/eogrow/utils/validators.py
@@ -3,6 +3,7 @@ Module defining common validators for schemas and validator wrappers
 """
 import datetime as dt
 import inspect
+from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Type, Union
 
 import numpy as np
@@ -36,6 +37,7 @@ def optional_field_validator(
     # In order to propagate the pydantic python magic we need a bit of python magic ourselves
     additional_args = inspect.getfullargspec(validator_fun).args[1:]
 
+    @wraps(validator_fun)
     def optional_validator(value, values, config, field):  # type: ignore[no-untyped-def]
         if value is not None:
             all_kwargs = {"values": values, "config": config, "field": field}

--- a/eogrow/utils/validators.py
+++ b/eogrow/utils/validators.py
@@ -42,6 +42,9 @@ def optional_field_validator(
             kwargs = {k: v for k, v in all_kwargs.items() if k in additional_args}
             return validator_fun(value, **kwargs)
         return None
+    
+    optional_validator.__name__ = f"optional_{validator_fun}"  # used for docbuilding purposes
+    # the correct way would be to use `functools.wraps` but this breaks pydantics python magic
 
     return validator(field, allow_reuse=allow_reuse, **kwargs)(optional_validator)
 

--- a/eogrow/utils/validators.py
+++ b/eogrow/utils/validators.py
@@ -42,8 +42,8 @@ def optional_field_validator(
             kwargs = {k: v for k, v in all_kwargs.items() if k in additional_args}
             return validator_fun(value, **kwargs)
         return None
-    
-    optional_validator.__name__ = f"optional_{validator_fun}"  # used for docbuilding purposes
+
+    optional_validator.__name__ = f"optional_{validator_fun.__name__}"  # used for docbuilding purposes
     # the correct way would be to use `functools.wraps` but this breaks pydantics python magic
 
     return validator(field, allow_reuse=allow_reuse, **kwargs)(optional_validator)

--- a/eogrow/utils/validators.py
+++ b/eogrow/utils/validators.py
@@ -135,7 +135,8 @@ class BandSchema(BaseModel):
 
 
 class DataCollectionSchema(BaseModel):
-    """Schema used in parsing DataCollection objects. Any extra parameters are passed to the definition as **params."""
+    """Schema used in parsing DataCollection objects. Any extra parameters are passed to the definition as `**params`.
+    """
 
     name: str = Field(
         "Name of the data collection. When defining BYOC collections use `BYOC_` prefix and for Batch collections use"
@@ -169,7 +170,7 @@ def parse_data_collection(value: Union[str, dict, DataCollection]) -> DataCollec
     """Validates and parses the data collection.
 
     If a string is given, then it tries to fetch a pre-defined collection. Otherwise it constructs a new collection
-    according to the prefix of the name (BYOC_ prefix to use `define_byoc` and `BATCH_` to use `define_batch`).
+    according to the prefix of the name (`BYOC_` prefix to use `define_byoc` and `BATCH_` to use `define_batch`).
     """
     if isinstance(value, DataCollection):
         return value  # required in order to allow default values

--- a/eogrow/utils/validators.py
+++ b/eogrow/utils/validators.py
@@ -43,10 +43,6 @@ def optional_field_validator(
             return validator_fun(value, **kwargs)
         return None
 
-    optional_validator.__name__ = f"optional_{validator_fun.__name__}"  # for docbuilding purposes
-    # the correct approach would be to use `functools.wraps` but this messes with the `inspect.signature` that
-    # pydantic magic uses
-
     return validator(field, allow_reuse=allow_reuse, **kwargs)(optional_validator)
 
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,4 @@
+autodoc_pydantic
 m2r2
 nbsphinx
 sphinx-rtd-theme


### PR DESCRIPTION
By leveraging `autodoc_pydantic` we now build far more understandable docs of Schema, which include validators/parsers and field descriptions