### PR TITLE
Pipeline for ingesting BYOC collections

### DIFF
--- a/eogrow/pipelines/export_maps.py
+++ b/eogrow/pipelines/export_maps.py
@@ -107,6 +107,7 @@ class ExportMapsPipeline(Pipeline):
 
         crs_eopatch_dict = self.eopatch_manager.split_by_utm(patch_names)
 
+        # TODO: This could be parallelized per-crs
         for crs, eopatch_list in crs_eopatch_dict.items():
             subfolder = f"UTM_{crs.epsg}"
             map_name = self.config.map_name or f"{feature_name}.tiff"

--- a/eogrow/pipelines/export_maps.py
+++ b/eogrow/pipelines/export_maps.py
@@ -40,7 +40,7 @@ class ExportMapsPipeline(Pipeline):
         )
 
         feature: Feature
-        map_name: str = Field(regex=r".+\.tiff?\b")  # noqa
+        map_name: Optional[str] = Field(regex=r".+\.tiff?\b")  # noqa
         map_dtype: Literal["int8", "int16", "uint8", "uint16", "float32"]
         no_data_value: int = Field(0, description="No data value to be passed to GeoTIFFs")
         scale_factor: Optional[float] = Field(description="Feature will be multiplied by this value at export")
@@ -67,7 +67,7 @@ class ExportMapsPipeline(Pipeline):
         successful, failed = super().run_procedure()
 
         _, feature_name = self.config.feature
-        self.create_maps(feature_name, self.config.map_name, successful)
+        self.create_maps(feature_name, successful)
 
         return successful, failed
 
@@ -84,7 +84,7 @@ class ExportMapsPipeline(Pipeline):
             rescale_task = LinearFunctionTask(self.config.feature, slope=self.config.scale_factor)
             task_list.append(rescale_task)
 
-        feature_name = self.config.feature[1]
+        _, feature_name = self.config.feature
         folder = fs.path.join(self.storage.get_folder(self.config.output_folder_key), feature_name)
         export_to_tiff_task = ExportToTiffTask(
             self.config.feature,
@@ -98,21 +98,21 @@ class ExportMapsPipeline(Pipeline):
 
         return EOWorkflow(linearly_connect_tasks(*task_list))
 
-    def create_maps(self, feature_name: str, map_name: str, patch_names: List[str], utm_split: bool = True) -> None:
+    def create_maps(self, feature_name: str, patch_names: List[str]) -> None:
         """A method which creates a joined GeoTIFF maps from a list of exported GeoTIFFs"""
         if not patch_names:
             raise ValueError("Cannot create map with an empty list of EOPatch names")
 
         folder = fs.path.join(self.storage.get_folder(self.config.output_folder_key), feature_name)
 
-        if utm_split:  # TODO: this can be parallelized but _create_single_map would have to become static
-            crs_eopatch_dict = self.eopatch_manager.split_by_utm(patch_names)
+        crs_eopatch_dict = self.eopatch_manager.split_by_utm(patch_names)
 
-            for crs, eopatch_list in crs_eopatch_dict.items():
-                utm_map_name = f"utm{crs.epsg}_{map_name}"
-                self._create_single_map(folder, eopatch_list, utm_map_name)
-        else:
-            self._create_single_map(folder, patch_names, map_name)
+        for crs, eopatch_list in crs_eopatch_dict.items():
+            subfolder_path = f"UTM_{crs.epsg}"
+            map_name = self.config.map_name or f"{feature_name}.tiff"
+
+            self.storage.filesystem.makedirs(fs.path.join(folder, subfolder_path), recreate=True)
+            self._create_single_map(folder, eopatch_list, fs.path.join(subfolder_path, map_name))
 
     def _create_single_map(self, folder: str, eopatch_list: List[str], map_name: str) -> None:
         """Creates a single map"""
@@ -169,9 +169,9 @@ class ExportMapsPipeline(Pipeline):
     def get_execution_arguments(self, workflow: EOWorkflow) -> List[Dict[EONode, Dict[str, object]]]:
         exec_args = super().get_execution_arguments(workflow)
         nodes = workflow.get_nodes()
-        for name, single_exec_dict in zip(self.patch_list, exec_args):
-            for node in nodes:
-                if isinstance(node.task, ExportToTiffTask):
+        for node in nodes:
+            if isinstance(node.task, ExportToTiffTask):
+                for name, single_exec_dict in zip(self.patch_list, exec_args):
                     single_exec_dict[node] = dict(filename=self.get_geotiff_name(name))
 
         return exec_args

--- a/eogrow/pipelines/ingest_byoc.py
+++ b/eogrow/pipelines/ingest_byoc.py
@@ -1,0 +1,155 @@
+import datetime
+import logging
+from collections import defaultdict
+from typing import Dict, List, Optional, Tuple, cast
+
+import fs
+import geopandas as gpd
+import pyproj
+import rasterio
+from pydantic import Field, validator
+
+from sentinelhub import CRS, BBox, DataCollection, SentinelHubBYOC
+from sentinelhub.api.byoc import ByocCollection, ByocTile
+from sentinelhub.geometry import Geometry
+
+from eogrow.core.config import RawConfig
+
+from ..core.pipeline import Pipeline
+from ..utils.types import JsonDict
+from ..utils.validators import (
+    ensure_defined_together,
+    ensure_exactly_one_defined,
+    optional_field_validator,
+    parse_data_collection,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+class IngestByocTilesPipeline(Pipeline):
+    """Ingests .tiff files to a BYOC collection. Based on `ExportMapsPipeline` output for timeless features."""
+
+    class Schema(Pipeline.Schema):
+        byoc_tile_folder_key: str
+        file_glob_pattern: str = Field("**/*.tif?", description="Pattern used for obtaining the TIFF files to use")
+
+        new_collection_name: Optional[str] = Field(description="Used for defining a new BYOC collection.")
+        existing_collection: Optional[DataCollection] = Field(description="Used when updating and reingesting.")
+        _parse_byoc_collection = optional_field_validator("existing_collection", parse_data_collection, pre=True)
+        _ensure_exclusion = ensure_exactly_one_defined("new_collection_name", "existing_collection")
+
+        sensing_time: datetime.datetime = Field(description="Sensing time (ISO format) added to BYOC tiles.")
+
+        @validator("sensing_time", pre=True)
+        def _parse_sensing_time(cls, value: str) -> datetime.datetime:
+            return datetime.datetime.fromisoformat(value)
+
+        cover_geometry_folder_key: Optional[str] = Field(description="Folder for supplying a custom cover geometry.")
+        cover_geometry: Optional[str] = Field(description="Specifies a geometry file describing the cover geometry.")
+        _ensure_cover_geometry = ensure_defined_together("cover_geometry_folder_key", "cover_geometry")
+
+    config: Schema
+
+    def __init__(self, config: Schema, raw_config: Optional[RawConfig] = None):
+        super().__init__(config, raw_config)
+        if not self.storage.is_on_aws:
+            raise ValueError("Can only ingest for projects based on S3 storage.")
+        project_folder = self.storage.config.project_folder
+        self.bucket_name = project_folder.split("/")[2]
+        self._cover_geometry_df: Optional[gpd.GeoDataFrame] = None
+
+    def get_byoc_collection(self, byoc_client: SentinelHubBYOC) -> JsonDict:
+        """Obtains information about the existing collection or creates a new one."""
+        if self.config.new_collection_name is not None:
+            collection_spec = ByocCollection(
+                self.config.new_collection_name,
+                s3_bucket=self.bucket_name,
+            )
+            LOGGER.info("Creating new collection.")
+            response = byoc_client.create_collection(collection_spec)
+        else:
+            existing_collection = cast(DataCollection, self.config.existing_collection)  # due to validation
+            LOGGER.info("Obtaining full information for collection id %s.", existing_collection.collection_id)
+            response = byoc_client.get_collection(existing_collection)
+        return response
+
+    def get_tile_paths(self) -> Dict[str, List[str]]:
+        """Collects the folders and filenames of .tiff files to be ingested.
+
+        Paths are relative to bucket, not project.
+        """
+        tiff_paths = self._get_tiff_paths()
+
+        folder_to_filename_map = defaultdict(list)
+        for folder, filename in map(fs.path.split, tiff_paths):
+            folder_to_filename_map[folder].append(filename)
+
+        return dict(folder_to_filename_map)
+
+    def _get_tiff_paths(self) -> List[str]:
+        """Collects the paths to .tiff files that are to be ingested.
+
+        Paths are relative to bucket, not project.
+        """
+        folder = self.storage.get_folder(key=self.config.byoc_tile_folder_key)
+        filesystem = self.storage.filesystem
+        return [
+            self._get_byoc_compliant_path(path)
+            for path, _ in filesystem.glob(path=folder, pattern=self.config.file_glob_pattern)
+        ]
+
+    def _get_byoc_compliant_path(self, relative_path: str) -> str:
+        absolute_path = fs.path.combine(self.config.storage.project_folder, relative_path)  # type: ignore[attr-defined]
+        return absolute_path[6 + len(self.bucket_name) :]  # removes s3://<bucket-name>/
+
+    def _prepare_tile(self, folder: str, tiff_paths: List[str]) -> ByocTile:
+        some_tiff = fs.path.join(folder, tiff_paths[0])
+        cover_geometry = self._get_tile_cover_geometry(some_tiff)
+        return ByocTile(folder, cover_geometry=cover_geometry, sensing_time=self.config.sensing_time)
+
+    def _get_cover_geometry(self, crs: pyproj.CRS) -> Optional[Geometry]:
+        if self.config.cover_geometry is None or self.config.cover_geometry_folder_key is None:
+            return None
+
+        if self._cover_geometry_df is None:
+            folder_path = self.storage.get_folder(self.config.cover_geometry_folder_key)
+            file_path = fs.path.join(folder_path, self.config.cover_geometry)
+            with self.storage.filesystem.openbin(file_path, "r") as file_handle:
+                self._cover_geometry_df = gpd.read_file(file_handle)
+
+        return self._cover_geometry_df.to_crs(crs).unary_union
+
+    def _get_tile_cover_geometry(self, tiff_path: str) -> Geometry:
+        full_path = f"s3://{self.bucket_name}/" + tiff_path
+        with rasterio.open(full_path) as tiff_data:
+            tiff_bounds = tiff_data.bounds
+            tiff_crs = CRS(tiff_data.crs.to_epsg())
+        tiff_poly = BBox([tiff_bounds.left, tiff_bounds.bottom, tiff_bounds.right, tiff_bounds.top], tiff_crs).geometry
+
+        cover_poly = self._get_cover_geometry(pyproj.CRS(tiff_crs.value))
+        final_poly = tiff_poly.intersection(cover_poly) if cover_poly else tiff_poly
+        return Geometry(final_poly, crs=tiff_crs)
+
+
+    def run_procedure(self) -> Tuple[List[str], List[str]]:
+        byoc_client = SentinelHubBYOC(config=self.storage.sh_config)
+        byoc_collection = self.get_byoc_collection(byoc_client)
+
+        finished, failed = [], []
+        for tile_folder, tiff_paths in self.get_tile_paths().items():
+            tile = self._prepare_tile(tile_folder, tiff_paths)
+            response = byoc_client.create_tile(byoc_collection, tile)
+            if "id" in response:
+                finished.append({"tile_id": response["id"], "tile_folder": tile_folder})
+            else:
+                failed.append({"tile_path": tile_folder, "error": response})
+
+        self.log_results(finished, failed)
+        # The returned finished/failed values are passed through an eopatch-name parsing, so it's not suitable for us
+        return [], []
+
+    def log_results(self, finished: List[dict], failed: List[dict]) -> None:
+        LOGGER.info("Successfully created %d / %d tiles.", len(finished), len(finished) + len(failed))
+        for fail in failed:
+            LOGGER.info("Ingestion of %s failed with response %s.", fail["tile_path"], fail["error"])

--- a/eogrow/utils/map.py
+++ b/eogrow/utils/map.py
@@ -92,7 +92,7 @@ def merge_maps(
     input_filename_list: List[str],
     merged_filename: str,
     *,
-    blocksize: int = 2048,
+    blocksize: int = 1024,
     nodata: Optional[float] = None,
     dtype: Literal[None, "int8", "int16", "uint8", "uint16", "float32"] = None,
     cogify: bool = False,

--- a/eogrow/utils/validators.py
+++ b/eogrow/utils/validators.py
@@ -70,6 +70,21 @@ def ensure_exactly_one_defined(param1: str, param2: str, allow_reuse: bool = Tru
     return root_validator(allow_reuse=allow_reuse, **kwargs)(ensure_exclusion)
 
 
+def ensure_defined_together(param1: str, param2: str, allow_reuse: bool = True, **kwargs: Any) -> classmethod:
+    """A root validator that makes sure that the two parameters are either both (un)defined."""
+
+    def ensure_exclusion(cls: type, values: RawSchemaDict) -> RawSchemaDict:
+        is_param1_defined = values.get(param1) is None
+        is_param2_defined = values.get(param2) is None
+        assert (
+            is_param1_defined == is_param2_defined
+        ), f"Both or neither of parameters `{param1}` and `{param2}` have to be specified."
+
+        return values
+
+    return root_validator(allow_reuse=allow_reuse, **kwargs)(ensure_exclusion)
+
+
 def parse_time_period(value: Tuple[str, str]) -> TimePeriod:
     """Allows parsing of preset options of shape `[preset_kind, year]` but that requires `pre` validation"""
     presets = ["yearly", "season", "Q1", "Q2", "Q3", "Q4", "Q1-yearly", "Q2-yearly", "Q3-yearly", "Q4-yearly"]

--- a/eogrow/utils/validators.py
+++ b/eogrow/utils/validators.py
@@ -71,7 +71,7 @@ def ensure_exactly_one_defined(param1: str, param2: str, allow_reuse: bool = Tru
 
 
 def ensure_defined_together(param1: str, param2: str, allow_reuse: bool = True, **kwargs: Any) -> classmethod:
-    """A root validator that makes sure that the two parameters are either both (un)defined."""
+    """A root validator that makes sure that the two parameters are both (un)defined."""
 
     def ensure_exclusion(cls: type, values: RawSchemaDict) -> RawSchemaDict:
         is_param1_defined = values.get(param1) is None

--- a/tests/test_config_files/export_maps/export_maps_mask.json
+++ b/tests/test_config_files/export_maps/export_maps_mask.json
@@ -4,7 +4,6 @@
   "input_folder_key": "data",
   "output_folder_key": "maps",
   "feature": ["mask", "CLM"],
-  "map_name": "clm_mask.tiff",
   "map_dtype": "uint16",
   "band_indices": [0],
   "cogify": true,

--- a/tests/test_stats/export_maps/export_maps_data.json
+++ b/tests/test_stats/export_maps/export_maps_data.json
@@ -1,107 +1,109 @@
 {
   "BANDS-S2-L1C": {
-    "utm32638_result.tiff": {
-      "image": {
-        "array_shape": [
-          35,
-          231,
-          264
-        ],
-        "basic_stats": {
-          "max": 0.6773,
-          "mean": 0.16853,
-          "median": 0.1497,
-          "min": 0.1147
-        },
-        "counts": {
-          "infinite": 0,
-          "nan": 0
-        },
-        "dtype": "float32",
-        "histogram": {
-          "counts": [
-            1928686,
-            60552,
-            13237,
-            50155,
-            55669,
-            18018,
-            5927,
-            2196
+    "UTM_32638": {
+      "result.tiff": {
+        "image": {
+          "array_shape": [
+            35,
+            231,
+            264
           ],
-          "edges": [
-            0.1147,
-            0.18502,
-            0.25535,
-            0.32567,
-            0.396,
-            0.46632,
-            0.53665,
-            0.60697,
-            0.6773
-          ]
+          "basic_stats": {
+            "max": 0.6773,
+            "mean": 0.16853,
+            "median": 0.1497,
+            "min": 0.1147
+          },
+          "counts": {
+            "infinite": 0,
+            "nan": 0
+          },
+          "dtype": "float32",
+          "histogram": {
+            "counts": [
+              1928686,
+              60552,
+              13237,
+              50155,
+              55669,
+              18018,
+              5927,
+              2196
+            ],
+            "edges": [
+              0.1147,
+              0.18502,
+              0.25535,
+              0.32567,
+              0.396,
+              0.46632,
+              0.53665,
+              0.60697,
+              0.6773
+            ]
+          },
+          "random_values": [
+            {
+              "position": [
+                32,
+                59,
+                243
+              ],
+              "value": 0.3945
+            },
+            {
+              "position": [
+                18,
+                161,
+                187
+              ],
+              "value": 0.3486
+            },
+            {
+              "position": [
+                30,
+                165,
+                111
+              ],
+              "value": 0.2066
+            },
+            {
+              "position": [
+                1,
+                77,
+                13
+              ],
+              "value": 0.2215
+            },
+            {
+              "position": [
+                32,
+                162,
+                231
+              ],
+              "value": 0.4772
+            }
+          ],
+          "subsample_basic_stats": {
+            "max": 0.6773,
+            "mean": 0.16838,
+            "median": 0.1497,
+            "min": 0.1147
+          }
         },
-        "random_values": [
-          {
-            "position": [
-              32,
-              59,
-              243
-            ],
-            "value": 0.3945
-          },
-          {
-            "position": [
-              18,
-              161,
-              187
-            ],
-            "value": 0.3486
-          },
-          {
-            "position": [
-              30,
-              165,
-              111
-            ],
-            "value": 0.2066
-          },
-          {
-            "position": [
-              1,
-              77,
-              13
-            ],
-            "value": 0.2215
-          },
-          {
-            "position": [
-              32,
-              162,
-              231
-            ],
-            "value": 0.4772
-          }
-        ],
-        "subsample_basic_stats": {
-          "max": 0.6773,
-          "mean": 0.16838,
-          "median": 0.1497,
-          "min": 0.1147
+        "mask": {
+          "array_shape": [
+            231,
+            264
+          ],
+          "dtype": "uint8",
+          "values": [
+            {
+              "count": 60984,
+              "value": 255
+            }
+          ]
         }
-      },
-      "mask": {
-        "array_shape": [
-          231,
-          264
-        ],
-        "dtype": "uint8",
-        "values": [
-          {
-            "count": 60984,
-            "value": 255
-          }
-        ]
       }
     }
   }

--- a/tests/test_stats/export_maps/export_maps_mask.json
+++ b/tests/test_stats/export_maps/export_maps_mask.json
@@ -1,54 +1,56 @@
 {
   "CLM": {
-    "utm32638_clm_mask.tiff": {
-      "image": {
-        "array_shape": [
-          35,
-          231,
-          264
-        ],
-        "dtype": "uint16",
-        "random_values": [
-          {
-            "position": [
-              16,
-              199,
-              219
-            ],
-            "value": 0
-          },
-          {
-            "position": [
-              18,
-              20,
-              58
-            ],
-            "value": 1
-          }
-        ],
-        "values": [
-          {
-            "count": 1897639,
-            "value": 0
-          },
-          {
-            "count": 236801,
-            "value": 1
-          }
-        ]
-      },
-      "mask": {
-        "array_shape": [
-          231,
-          264
-        ],
-        "dtype": "uint8",
-        "values": [
-          {
-            "count": 60984,
-            "value": 255
-          }
-        ]
+    "UTM_32638": {
+      "CLM.tiff": {
+        "image": {
+          "array_shape": [
+            35,
+            231,
+            264
+          ],
+          "dtype": "uint16",
+          "random_values": [
+            {
+              "position": [
+                16,
+                199,
+                219
+              ],
+              "value": 0
+            },
+            {
+              "position": [
+                18,
+                20,
+                58
+              ],
+              "value": 1
+            }
+          ],
+          "values": [
+            {
+              "count": 1897639,
+              "value": 0
+            },
+            {
+              "count": 236801,
+              "value": 1
+            }
+          ]
+        },
+        "mask": {
+          "array_shape": [
+            231,
+            264
+          ],
+          "dtype": "uint8",
+          "values": [
+            {
+              "count": 60984,
+              "value": 255
+            }
+          ]
+        }
       }
     }
   }


### PR DESCRIPTION
1. Changes output of `ExportMapsPipeline` to save each map to its own subfolder (instead of using a prefix), which makes it easier to ingest them as BYOC collections. Name is now also optional (feature name is used if not provided). Tests are updated.
2. Add generic validator for checking that two parameters are defined at the same time. Tests are updated.
3. Add a pipeline that accepts the output of an `ExportMapsPipeline` and ingests the tiffs as a BYOC collection. No tests yet.