### PR TITLE
Fix setting of nodata in export2tiff pipeline, round 2

### DIFF
--- a/eogrow/utils/map.py
+++ b/eogrow/utils/map.py
@@ -142,7 +142,7 @@ def merge_tiffs(
     gdalmerge_options = "-co BIGTIFF=YES -co compress=LZW"
 
     if nodata is not None:
-        gdalmerge_options += f" -a_nodata {nodata}"
+        gdalmerge_options += f' -init "{nodata}" -a_nodata "{nodata}"'
 
     if dtype is not None:
         gdalmerge_options += f" {GDAL_DTYPE_SETTINGS[dtype]}"


### PR DESCRIPTION
ExportToTiff pipeline didn't behave as expected. When merging tiffs, I wanted to set the empty space to the no-data value, turns out there were issues because of:
- not setting the `-init` param
- not using the values as strings (- was understood as a parameter???)

Thanks @batic for the help.