### PR TITLE
Make export pipeline logs more readable

### DIFF
--- a/eogrow/pipelines/export_maps.py
+++ b/eogrow/pipelines/export_maps.py
@@ -125,14 +125,12 @@ class ExportMapsPipeline(Pipeline):
                 output_paths = self._split_temporally(filesystem, map_path, timestamp, output_folder)
 
             if self.config.cogify:
-                resampling = "NEAREST" if feature_type.is_discrete() else "AVERAGE"
                 for path, _ in tqdm(output_paths, desc="Cogifying output"):
                     cogify_inplace(
                         filesystem.getsyspath(path),
                         blocksize=1024,
                         nodata=self.config.no_data_value,
                         dtype=self.config.map_dtype,
-                        resampling=resampling,
                         quiet=True,
                     )
 

--- a/eogrow/pipelines/export_maps.py
+++ b/eogrow/pipelines/export_maps.py
@@ -125,7 +125,7 @@ class ExportMapsPipeline(Pipeline):
                 output_paths = self._split_temporally(filesystem, map_path, timestamp, output_folder)
 
             if self.config.cogify:
-                resampling = "mode" if feature_type.is_discrete() else "bilinear"
+                resampling = "NEAREST" if feature_type.is_discrete() else "AVERAGE"
                 for path, _ in tqdm(output_paths, desc="Cogifying output"):
                     cogify_inplace(
                         filesystem.getsyspath(path),

--- a/eogrow/utils/map.py
+++ b/eogrow/utils/map.py
@@ -5,6 +5,7 @@ import logging
 import os
 import shutil
 import subprocess
+import warnings
 from tempfile import NamedTemporaryFile
 from typing import List, Literal, Optional, Sequence
 
@@ -74,6 +75,14 @@ def cogify(
             os.remove(output_file)
         else:
             raise OSError(f"{output_file} exists!")
+
+    version = subprocess.check_output(("gdalinfo", "--version"), text=True).split(",")[0].replace("GDAL ", "")
+    if version < "3.1.0":
+        warnings.warn(
+            f"The cogification process is configured for GDAL 3.1.0 and higher, but version {version} was detected, "
+            "which might result in issues.",
+            RuntimeWarning,
+        )
 
     resampling = "AVERAGE" if dtype == "float32" else "NEAREST"
     predictor = 3 if dtype == "float32" else 2

--- a/eogrow/utils/map.py
+++ b/eogrow/utils/map.py
@@ -23,7 +23,6 @@ def cogify_inplace(
     blocksize: int = 2048,
     nodata: Optional[float] = None,
     dtype: Literal[None, "int8", "int16", "uint8", "uint16", "float32"] = None,
-    resampling: str = "AVERAGE",
     quiet: bool = False,
 ) -> None:
     """Make the (geotiff) file a cog
@@ -31,7 +30,6 @@ def cogify_inplace(
     :param blocksize: block size of tiled COG
     :param nodata: value to be treated as nodata, default value is None
     :param dtype: output type of the in the resulting tiff, default is None
-    :param resampling: The mode of resampling to use. NEAREST should be used for integers and AVERAGE for floats.
     :param quiet: The process does not produce logs.
     """
     temp_file = NamedTemporaryFile()
@@ -44,7 +42,6 @@ def cogify_inplace(
         nodata=nodata,
         dtype=dtype,
         overwrite=True,
-        resampling=resampling,
         quiet=quiet,
     )
     shutil.move(temp_file.name, tiff_file)
@@ -57,7 +54,6 @@ def cogify(
     nodata: Optional[float] = None,
     dtype: Literal[None, "int8", "int16", "uint8", "uint16", "float32"] = None,
     overwrite: bool = False,
-    resampling: str = "AVERAGE",
     quiet: bool = False,
 ) -> None:
     """Create a cloud optimized version of input file
@@ -68,7 +64,6 @@ def cogify(
     :param nodata: value to be treated as nodata, default value is None
     :param dtype: output type of the in the resulting tiff, default is None
     :param overwrite: If True overwrite the output file if it exists.
-    :param resampling: The mode of resampling to use. NEAREST should be used for integers and AVERAGE for floats.
     :param quiet: The process does not produce logs.
     """
     if input_file == output_file:
@@ -80,9 +75,12 @@ def cogify(
         else:
             raise OSError(f"{output_file} exists!")
 
+    resampling = "AVERAGE" if dtype == "float32" else "NEAREST"
+    predictor = 3 if dtype == "float32" else 2
+
     gdaltranslate_options = (
-        f"-of COG -co COMPRESS=DEFLATE -co BLOCKSIZE={blocksize} -co RESAMPLING={resampling} -co"
-        " OVERVIEWS=IGNORE_EXISTING"
+        f"-of COG -co COMPRESS=DEFLATE -co BLOCKSIZE={blocksize} -co RESAMPLING={resampling} "
+        f"-co OVERVIEWS=IGNORE_EXISTING -co PREDICTOR={predictor}"
     )
 
     if quiet:

--- a/eogrow/utils/map.py
+++ b/eogrow/utils/map.py
@@ -80,15 +80,12 @@ def cogify(
         else:
             raise OSError(f"{output_file} exists!")
 
-    gdaladdo_options = f"-r {resampling} --config GDAL_TIFF_OVR_BLOCKSIZE {blocksize} 2 4 8 16 32"
-
     gdaltranslate_options = (
-        f"-co TILED=YES --config GDAL_TIFF_OVR_BLOCKSIZE {blocksize} -co BLOCKXSIZE={blocksize} "
-        f"-co BLOCKYSIZE={blocksize} -co COMPRESS=DEFLATE"
+        f"-of COG -co COMPRESS=DEFLATE -co BLOCKSIZE={blocksize} -co RESAMPLING={resampling} -co"
+        " OVERVIEWS=IGNORE_EXISTING"
     )
 
     if quiet:
-        gdaladdo_options += " -q"
         gdaltranslate_options += " -q"
 
     if nodata is not None:
@@ -101,7 +98,6 @@ def cogify(
     temp_filename.close()
     shutil.copyfile(input_file, temp_filename.name)
 
-    subprocess.check_call(f"gdaladdo {temp_filename.name} {gdaladdo_options}", shell=True)
     subprocess.check_call(f"gdal_translate {gdaltranslate_options} {temp_filename.name} {output_file}", shell=True)
 
 

--- a/eogrow/utils/map.py
+++ b/eogrow/utils/map.py
@@ -23,7 +23,7 @@ def cogify_inplace(
     blocksize: int = 2048,
     nodata: Optional[float] = None,
     dtype: Literal[None, "int8", "int16", "uint8", "uint16", "float32"] = None,
-    resampling: str = "mode",
+    resampling: str = "AVERAGE",
     quiet: bool = False,
 ) -> None:
     """Make the (geotiff) file a cog
@@ -31,7 +31,7 @@ def cogify_inplace(
     :param blocksize: block size of tiled COG
     :param nodata: value to be treated as nodata, default value is None
     :param dtype: output type of the in the resulting tiff, default is None
-    :param resampling: The mode of resampling to use. Mode should be used for integers and bilinear for floats.
+    :param resampling: The mode of resampling to use. NEAREST should be used for integers and AVERAGE for floats.
     :param quiet: The process does not produce logs.
     """
     temp_file = NamedTemporaryFile()
@@ -57,7 +57,7 @@ def cogify(
     nodata: Optional[float] = None,
     dtype: Literal[None, "int8", "int16", "uint8", "uint16", "float32"] = None,
     overwrite: bool = False,
-    resampling: str = "mode",
+    resampling: str = "AVERAGE",
     quiet: bool = False,
 ) -> None:
     """Create a cloud optimized version of input file
@@ -68,7 +68,7 @@ def cogify(
     :param nodata: value to be treated as nodata, default value is None
     :param dtype: output type of the in the resulting tiff, default is None
     :param overwrite: If True overwrite the output file if it exists.
-    :param resampling: The mode of resampling to use. Mode should be used for integers and bilinear for floats.
+    :param resampling: The mode of resampling to use. NEAREST should be used for integers and AVERAGE for floats.
     :param quiet: The process does not produce logs.
     """
     if input_file == output_file:

--- a/tests/test_utils/test_map.py
+++ b/tests/test_utils/test_map.py
@@ -46,14 +46,14 @@ class TestCogify:
         return filesystem.getsyspath("output.tif")
 
     @pytest.mark.parametrize("dtype", GDAL_DTYPE_SETTINGS)
-    @pytest.mark.parametrize("block", (1024, 64))
+    @pytest.mark.parametrize("block", (1024, 128))
     @pytest.mark.parametrize("nodata", (None, 0, 11))
     def test_cogify(self, input_path: str, output_path: str, nodata: Optional[float], dtype: str, block: int) -> None:
         cogify(input_path, output_path, nodata=nodata, dtype=dtype, blocksize=block, overwrite=True)
         self._test_output_file(output_path, nodata, dtype, block)
 
     @pytest.mark.parametrize("dtype", ("float32", "uint8"))
-    @pytest.mark.parametrize("block", (1024, 64))
+    @pytest.mark.parametrize("block", (1024, 128))
     @pytest.mark.parametrize("nodata", (None, 11))
     def test_cogify_inplace(self, input_path: str, nodata: Optional[float], dtype: str, block: int) -> None:
         cogify_inplace(input_path, nodata=nodata, dtype=dtype, blocksize=block)


### PR DESCRIPTION
Silences output of gdal calls in favor of tqdm, making logs much more readable.

In the logs there was a constant warning:
```
Warning 1: General options of gdal_translate make the COPY_SRC_OVERVIEWS creation option ineffective as they hide the overviews
```

I have removed this option in this MR, but it should be investigated if that is really the way to go. Link to [cogification docs](https://gdal.org/drivers/raster/cog.html#raster-cog)