### PR TITLE
Add warp resampling when merging tiffs.

### DIFF
--- a/eogrow/utils/map.py
+++ b/eogrow/utils/map.py
@@ -122,26 +122,21 @@ def merge_tiffs(
     :param delete_input: If True input images will be deleted at the end
     :param quiet: The process does not produce logs.
     """
-    if os.path.exists(merged_filename):
-        if overwrite:
-            os.remove(merged_filename)
-        else:
-            raise OSError(f"{merged_filename} exists!")
+    gdalwarp_options = "-co BIGTIFF=YES -co compress=LZW -co TILED=YES"
 
-    gdalmerge_options = "-co BIGTIFF=YES -co compress=LZW"
-
+    if overwrite:
+        gdalwarp_options += " -overwrite"
     if quiet:
-        gdalmerge_options += " -q"
+        gdalwarp_options += " -q"
 
     if nodata is not None:
-        gdalmerge_options += f' -init "{nodata}" -a_nodata "{nodata}"'
+        gdalwarp_options += f' -dstnodata "{nodata}"'
 
     if dtype is not None:
-        gdalmerge_options += f" {GDAL_DTYPE_SETTINGS[dtype]}"
+        gdalwarp_options += f" {GDAL_DTYPE_SETTINGS[dtype]}"
 
-    subprocess.check_call(
-        f"gdal_merge.py {gdalmerge_options} -o {merged_filename} {' '.join(input_filename_list)}", shell=True
-    )
+    command = f"gdalwarp {gdalwarp_options} {' '.join(input_filename_list)} {merged_filename} "
+    subprocess.check_call(command, shell=True)
 
 
 def extract_bands(

--- a/tests/test_config_files/export_maps/export_maps_data.json
+++ b/tests/test_config_files/export_maps/export_maps_data.json
@@ -13,5 +13,6 @@
   "map_dtype": "float32",
   "band_indices": [0, 1],
   "cogify": true,
+  "warp_resampling": "bilinear",
   "workers": 1
 }

--- a/tests/test_utils/test_map.py
+++ b/tests/test_utils/test_map.py
@@ -15,7 +15,14 @@ from eolearn.core import EOPatch, FeatureType
 from eolearn.io import ExportToTiffTask
 from sentinelhub import CRS, BBox
 
-from eogrow.utils.map import GDAL_DTYPE_SETTINGS, cogify, cogify_inplace, extract_bands, merge_tiffs
+from eogrow.utils.map import (
+    GDAL_DTYPE_SETTINGS,
+    CogifyResamplingOptions,
+    cogify,
+    cogify_inplace,
+    extract_bands,
+    merge_tiffs,
+)
 
 pytestmark = pytest.mark.fast
 
@@ -55,7 +62,9 @@ class TestCogify:
     @pytest.mark.parametrize(
         "dtype, resampling", [("float32", "AVERAGE"), ("int16", "MODE"), ("float32", "BILINEAR"), ("uint8", None)]
     )
-    def test_cogify_resampling(self, input_path: str, output_path: str, dtype: str, resampling) -> None:
+    def test_cogify_resampling(
+        self, input_path: str, output_path: str, dtype: str, resampling: CogifyResamplingOptions
+    ) -> None:
         cogify(input_path, output_path, dtype=dtype, resampling=resampling, overwrite=True)
         self._test_output_file(output_path, None, dtype, 1024)
 


### PR DESCRIPTION
By switching from `gdal_merge` to `gdalwarp` we can now specify how to resample tiffs that are warped. This is a possible improvement for pixel misalignment.

Another benefit is that `gdal_merge` loads all files into memory while `gdalwarp` runs much more memory-conservative.