### PR TITLE
Improvements for ExportToTiff pipeline

### DIFF
--- a/eogrow/pipelines/export_maps.py
+++ b/eogrow/pipelines/export_maps.py
@@ -125,7 +125,7 @@ class ExportMapsPipeline(Pipeline):
                 warp_resampling=self.config.warp_resampling,
             )
 
-            LOGGER.info("Remove local per-eopatch tiffs after merge.", crs.epsg)
+            LOGGER.info("Remove local per-eopatch tiffs after merge.")
             parallelize(filesystem.remove, geotiff_paths, workers=None, multiprocess=False, desc="Remove tiffs")
 
             output_paths: List[Tuple[str, Optional[dt.datetime]]]

--- a/eogrow/pipelines/export_maps.py
+++ b/eogrow/pipelines/export_maps.py
@@ -20,6 +20,7 @@ from eolearn.core.utils.fs import get_full_path
 from eolearn.core.utils.parallelize import parallelize
 from eolearn.features import LinearFunctionTask
 from eolearn.io import ExportToTiffTask
+from sentinelhub import CRS
 
 from ..core.pipeline import Pipeline
 from ..utils.map import CogifyResamplingOptions, WarpResamplingOptions, cogify_inplace, extract_bands, merge_tiffs
@@ -102,7 +103,6 @@ class ExportMapsPipeline(Pipeline):
         folder = self.storage.get_folder(self.config.output_folder_key)
         crs_eopatch_dict = self.eopatch_manager.split_by_utm(successful)
 
-        # TODO: This could be parallelized per-crs
         for crs, eopatch_list in crs_eopatch_dict.items():
             LOGGER.info("Processing for UTM %d", crs.epsg)
 
@@ -110,7 +110,7 @@ class ExportMapsPipeline(Pipeline):
             # manually make subfolder, otherwise things fail on S3 in later steps
             self.storage.filesystem.makedirs(output_folder, recreate=True)
 
-            merged_map_path = fs.path.join(output_folder, self.get_geotiff_name("full_merged_map"))
+            merged_map_path = fs.path.join(output_folder, self.get_geotiff_name("merged", crs=crs))
             exported_tiff_paths = [fs.path.join(folder, self.get_geotiff_name(name)) for name in eopatch_list]
 
             filesystem, geotiff_paths, map_path = self._prepare_files(exported_tiff_paths, merged_map_path)
@@ -133,7 +133,7 @@ class ExportMapsPipeline(Pipeline):
                 output_paths = [(map_path, None)]
             else:
                 timestamp = self._load_timestamp(eopatch_list[0])  # we assume all eopatches share the same timestamp
-                output_paths = self._split_temporally(filesystem, map_path, timestamp, output_folder)
+                output_paths = self._split_temporally(filesystem, map_path, timestamp, output_folder, crs)
 
             if self.config.cogify:
                 LOGGER.info("Cogifying %d merged tiffs.", len(output_paths))
@@ -152,14 +152,15 @@ class ExportMapsPipeline(Pipeline):
             if isinstance(filesystem, TempFS):
                 filesystem.close()
 
-            LOGGER.info("Remove per-eopatch tiffs for UTM %d.", crs.epsg)
-            parallelize(
-                self.storage.filesystem.remove,
-                exported_tiff_paths,
-                workers=None,
-                multiprocess=False,
-                desc="Remove tiffs",
-            )
+                # for non-tempfs runs this is already done right after merging
+                LOGGER.info("Remove per-eopatch tiffs for UTM %d from storage.", crs.epsg)
+                parallelize(
+                    self.storage.filesystem.remove,
+                    exported_tiff_paths,
+                    workers=None,
+                    multiprocess=False,
+                    desc="Remove tiffs",
+                )
 
         return successful, failed
 
@@ -198,12 +199,18 @@ class ExportMapsPipeline(Pipeline):
 
         return exec_args
 
-    def get_geotiff_name(self, name: str) -> str:
-        """Creates a unique name of a geotiff image"""
-        return f"{name}_{self._get_map_name()}.tiff"
+    def get_geotiff_name(self, name: str, crs: Optional[CRS] = None, time: Optional[dt.datetime] = None) -> str:
+        """Creates a name of a geotiff image"""
+        base = f"{self._get_map_name(with_extension=False)}_{name}"
+        if crs is not None:
+            base += f"_UTM_{crs.epsg}"
+        if time is not None:
+            base += f"_{time.strftime(TIMESTAMP_FORMAT)}"
+        return f"{base}.tiff"
 
-    def _get_map_name(self) -> str:
-        return self.config.map_name or f"{self.config.feature[1]}.tiff"
+    def _get_map_name(self, with_extension: bool = True) -> str:
+        name = self.config.map_name or f"{self.config.feature[1]}.tiff"
+        return name if with_extension else name.replace(".tiff", "")
 
     def _prepare_files(self, geotiff_paths: List[str], output_file: str) -> Tuple[FS, List[str], str]:
         """Returns system paths of geotiffs and output file that can be used to merge maps.
@@ -238,7 +245,7 @@ class ExportMapsPipeline(Pipeline):
         return patch.timestamp
 
     def _split_temporally(
-        self, filesystem: FS, map_path: str, timestamp: List[dt.datetime], output_folder: str
+        self, filesystem: FS, map_path: str, timestamp: List[dt.datetime], output_folder: str, crs: CRS
     ) -> List[Tuple[str, Optional[dt.datetime]]]:
         """Splits the merged tiff into multiple tiffs, one per timestamp."""
         filesystem.makedirs(output_folder, recreate=True)  # in case we use a temporary filesystem
@@ -250,7 +257,7 @@ class ExportMapsPipeline(Pipeline):
         LOGGER.info("Splitting merged tiff into per-timestamp tiff files.")
         outputs: List[Tuple[str, Optional[dt.datetime]]] = []
         for i, time in tqdm(enumerate(timestamp), desc="Spliting per timestamp", total=len(timestamp)):
-            name = self.get_geotiff_name(f"full_merged_map_{time.strftime(TIMESTAMP_FORMAT)}")
+            name = self.get_geotiff_name("merged", crs, time)
             extraction_path = fs.path.join(output_folder, name)
             bands = range(i * num_bands, (i + 1) * num_bands)
             extract_bands(filesystem.getsyspath(map_path), filesystem.getsyspath(extraction_path), bands, quiet=True)

--- a/eogrow/pipelines/export_maps.py
+++ b/eogrow/pipelines/export_maps.py
@@ -123,8 +123,10 @@ class ExportMapsPipeline(Pipeline):
                 nodata=self.config.no_data_value,
                 dtype=self.config.map_dtype,
                 warp_resampling=self.config.warp_resampling,
-                quiet=True,
             )
+
+            LOGGER.info("Remove local per-eopatch tiffs after merge.", crs.epsg)
+            parallelize(filesystem.remove, geotiff_paths, workers=None, multiprocess=False, desc="Remove tiffs")
 
             output_paths: List[Tuple[str, Optional[dt.datetime]]]
             if feature_type.is_timeless() or self.config.compress_temporally:

--- a/eogrow/utils/map.py
+++ b/eogrow/utils/map.py
@@ -109,7 +109,6 @@ def cogify(
 
     gdaltranslate_options = (
         f"-of COG -co COMPRESS=DEFLATE -co BLOCKSIZE={blocksize} -co OVERVIEWS=IGNORE_EXISTING -co PREDICTOR=YES"
-        " --config GDAL_CACHEMAX 1000 -wm 1000 -multi"
     )
 
     if resampling:
@@ -150,7 +149,7 @@ def merge_tiffs(
     :param warp_resampling: The resampling method used when warping, useful for pixel misalignment. Defaults to NEAREST.
     :param quiet: The process does not produce logs.
     """
-    gdalwarp_options = "-co BIGTIFF=YES -co compress=LZW -co TILED=YES"
+    gdalwarp_options = "-co BIGTIFF=YES -co compress=LZW -co TILED=YES --config GDAL_CACHEMAX 1000 -wm 1000 -multi"
 
     if overwrite:
         gdalwarp_options += " -overwrite"

--- a/eogrow/utils/map.py
+++ b/eogrow/utils/map.py
@@ -150,7 +150,7 @@ def merge_tiffs(
     :param warp_resampling: The resampling method used when warping, useful for pixel misalignment. Defaults to NEAREST.
     :param quiet: The process does not produce logs.
     """
-    gdalwarp_options = "-co BIGTIFF=YES -co compress=LZW -co TILED=YES --config GDAL_CACHEMAX 1000 -wm 1000 -multi"
+    gdalwarp_options = "-co BIGTIFF=YES -co compress=LZW -co TILED=YES"
 
     if overwrite:
         gdalwarp_options += " -overwrite"

--- a/eogrow/utils/map.py
+++ b/eogrow/utils/map.py
@@ -66,6 +66,7 @@ def cogify_inplace(
         resampling=resampling,
         quiet=quiet,
     )
+    # Note: by moving the file we also remove the one at temp_file.name
     shutil.move(temp_file.name, tiff_file)
 
 
@@ -202,8 +203,4 @@ def extract_bands(
     if quiet:
         translate_opts += " -q"
 
-    temp_filename = NamedTemporaryFile()
-    temp_filename.close()
-    shutil.copyfile(input_file, temp_filename.name)
-
-    subprocess.check_call(f"gdal_translate {translate_opts} {temp_filename.name} {output_file}", shell=True)
+    subprocess.check_call(f"gdal_translate {translate_opts} {input_file} {output_file}", shell=True)

--- a/eogrow/utils/map.py
+++ b/eogrow/utils/map.py
@@ -109,6 +109,7 @@ def cogify(
 
     gdaltranslate_options = (
         f"-of COG -co COMPRESS=DEFLATE -co BLOCKSIZE={blocksize} -co OVERVIEWS=IGNORE_EXISTING -co PREDICTOR=YES"
+        " --config GDAL_CACHEMAX 1000 -wm 1000 -multi"
     )
 
     if resampling:


### PR DESCRIPTION
1. Removes disk-space issue that occurs due to `extract_bands` utility function not cleaning up after copying. The copying was deemed not necessary, since the utility function doesn't get used in-place (and if it does the user should take care of copying)
2. Local eo-patch tiffs are removed ASAP to preserve disk space
3. Tiffs are exported with compression. Makes the pipeline a bit slower, but saves on space (50% reduction in file-size). The names are also no longer unique-per-run, so subsequent runs override the previous ones (if the previous pipeline failed), reducing the clutter on storage when debugging.