### PR TITLE
Parallelize export maps

### DIFF
--- a/eogrow/pipelines/export_maps.py
+++ b/eogrow/pipelines/export_maps.py
@@ -186,7 +186,7 @@ class ExportMapsPipeline(Pipeline):
             no_data_value=self.config.no_data_value,
             image_dtype=np.dtype(self.config.map_dtype),
             band_indices=self.config.band_indices,
-            compress="LZW",
+            # compress="LZW",
         )
         task_list.append(export_to_tiff_task)
 

--- a/eogrow/pipelines/export_maps.py
+++ b/eogrow/pipelines/export_maps.py
@@ -175,7 +175,6 @@ class ExportMapsPipeline(Pipeline):
             no_data_value=self.config.no_data_value,
             image_dtype=np.dtype(self.config.map_dtype),
             band_indices=self.config.band_indices,
-            # compress="LZW",
         )
         task_list.append(export_to_tiff_task)
 

--- a/eogrow/pipelines/export_maps.py
+++ b/eogrow/pipelines/export_maps.py
@@ -335,7 +335,11 @@ class SplitTiffsJob:
 
 @dataclass
 class CombineTiffsJob:
-    """Describes which tiffs to merge, what the output path is, and the time the merged tiff represents."""
+    """Describes which tiffs to merge, what the output path is, and the time the merged tiff represents.
+
+    The time is relevant in order to correctly place the finalized tiff. If left out then the tiffs are either
+    timeless or not split temporally.
+    """
 
     input_paths: Iterable[str]
     output_path: str

--- a/eogrow/pipelines/export_maps.py
+++ b/eogrow/pipelines/export_maps.py
@@ -47,7 +47,7 @@ class ExportMapsPipeline(Pipeline):
         feature: Feature
         map_name: Optional[str] = Field(regex=r".+\." + MimeType.TIFF.extension + r"?\b")  # noqa
         map_dtype: Literal["int8", "int16", "uint8", "uint16", "float32"]
-        no_data_value: int = Field(0, description="No data value to be passed to GeoTIFFs")
+        no_data_value: Optional[float] = Field(description="No data value to be passed to GeoTIFFs")
         scale_factor: Optional[float] = Field(description="Feature will be multiplied by this value at export")
         band_indices: Optional[List[int]] = Field(
             description="A list of band indices to be exported for the export feature. Default is all bands"

--- a/eogrow/pipelines/export_maps.py
+++ b/eogrow/pipelines/export_maps.py
@@ -269,7 +269,7 @@ class ExportMapsPipeline(Pipeline):
     def _execute_split_jobs(jobs: List[dict]) -> None:
         """Executes all the jobs for a specific tiff. This prevents parallel processes fighting over IO to a tiff."""
         for job in jobs:
-            extract_bands(job["sys_input_path"], job["sys_output_path"], job["bands"], overwrite=True, quiet=True)
+            extract_bands(job["sys_input_path"], job["sys_output_path"], job["bands"])
 
     @staticmethod
     def _combine_geotiffs(
@@ -278,13 +278,11 @@ class ExportMapsPipeline(Pipeline):
         """Merges tiffs and cogifies them if needed. Also removes the pre-merge tiffs."""
         filesystem = unpickle_fs(pickled_filesystem)
         merge_tiffs(
-            list(map(filesystem.getsyspath, tiff_paths)),
+            map(filesystem.getsyspath, tiff_paths),
             filesystem.getsyspath(merged_map_path),
-            overwrite=True,
             nodata=config.no_data_value,
             dtype=config.map_dtype,
             warp_resampling=config.warp_resampling,
-            quiet=True,
         )
         for tiff_path in tiff_paths:
             filesystem.remove(tiff_path)
@@ -295,7 +293,6 @@ class ExportMapsPipeline(Pipeline):
                 blocksize=1024,
                 nodata=config.no_data_value,
                 dtype=config.map_dtype,
-                quiet=True,
                 resampling=config.cogification_resampling,
             )
 

--- a/eogrow/utils/map.py
+++ b/eogrow/utils/map.py
@@ -199,7 +199,8 @@ def extract_bands(
             raise OSError(f"{output_file} already exists. Set `overwrite` to true if it should be overwritten.")
 
     # gdal_translate starts indexation at 1
-    translate_opts = "-co compress=LZW" + " ".join(f" -b {band + 1}" for band in bands)
+    # translate_opts = "-co compress=LZW" + " ".join(f" -b {band + 1}" for band in bands)
+    translate_opts = " ".join(f" -b {band + 1}" for band in bands)
     if quiet:
         translate_opts += " -q"
 

--- a/eogrow/utils/map.py
+++ b/eogrow/utils/map.py
@@ -124,11 +124,7 @@ def cogify(
     if dtype is not None:
         gdaltranslate_options += f" -ot {GDAL_DTYPE_SETTINGS[dtype]}"
 
-    temp_filename = NamedTemporaryFile()
-    temp_filename.close()
-    shutil.copyfile(input_file, temp_filename.name)
-
-    subprocess.check_call(f"gdal_translate {gdaltranslate_options} {temp_filename.name} {output_file}", shell=True)
+    subprocess.check_call(f"gdal_translate {gdaltranslate_options} {input_file} {output_file}", shell=True)
 
 
 def merge_tiffs(

--- a/eogrow/utils/map.py
+++ b/eogrow/utils/map.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import subprocess
 from tempfile import NamedTemporaryFile
-from typing import List, Literal, Optional, Sequence
+from typing import Iterable, Literal, Optional
 
 LOGGER = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ def cogify_inplace(
     nodata: Optional[float] = None,
     dtype: Literal[None, "int8", "int16", "uint8", "uint16", "float32"] = None,
     resampling: CogifyResamplingOptions = None,
-    quiet: bool = False,
+    quiet: bool = True,
 ) -> None:
     """Make the (geotiff) file a cog
     :param tiff_file: .tiff file to cogify
@@ -76,9 +76,9 @@ def cogify(
     blocksize: int = 1024,
     nodata: Optional[float] = None,
     dtype: Literal[None, "int8", "int16", "uint8", "uint16", "float32"] = None,
-    overwrite: bool = False,
+    overwrite: bool = True,
     resampling: CogifyResamplingOptions = None,
-    quiet: bool = False,
+    quiet: bool = True,
 ) -> None:
     """Create a cloud optimized version of input file
 
@@ -128,18 +128,18 @@ def cogify(
 
 
 def merge_tiffs(
-    input_filename_list: List[str],
+    input_filenames: Iterable[str],
     merged_filename: str,
     *,
-    overwrite: bool = False,
+    overwrite: bool = True,
     nodata: Optional[float] = None,
     dtype: Literal[None, "int8", "int16", "uint8", "uint16", "float32"] = None,
     warp_resampling: WarpResamplingOptions = None,
-    quiet: bool = False,
+    quiet: bool = True,
 ) -> None:
     """Performs gdal_merge on a set of given geotiff images
 
-    :param input_filename_list: A list of input tiff image filenames
+    :param input_filenames: A sequence of input tiff image filenames
     :param merged_filename: Filename of merged tiff image
     :param overwrite: If True overwrite the output (merged) file if it exists
     :param delete_input: If True input images will be deleted at the end
@@ -163,16 +163,16 @@ def merge_tiffs(
     if dtype is not None:
         gdalwarp_options += f" -ot {GDAL_DTYPE_SETTINGS[dtype]}"
 
-    command = f"gdalwarp {gdalwarp_options} {' '.join(input_filename_list)} {merged_filename}"
+    command = f"gdalwarp {gdalwarp_options} {' '.join(input_filenames)} {merged_filename}"
     subprocess.check_call(command, shell=True)
 
 
 def extract_bands(
     input_file: str,
     output_file: str,
-    bands: Sequence[int],
-    overwrite: bool = False,
-    quiet: bool = False,
+    bands: Iterable[int],
+    overwrite: bool = True,
+    quiet: bool = True,
 ) -> None:
     """Extract bands from given input file
 

--- a/eogrow/utils/map.py
+++ b/eogrow/utils/map.py
@@ -172,6 +172,7 @@ def extract_bands(
     output_file: str,
     bands: Iterable[int],
     overwrite: bool = True,
+    compress: bool = False,
     quiet: bool = True,
 ) -> None:
     """Extract bands from given input file
@@ -195,10 +196,11 @@ def extract_bands(
             raise OSError(f"{output_file} already exists. Set `overwrite` to true if it should be overwritten.")
 
     # gdal_translate starts indexation at 1
-    # translate_opts = "-co compress=LZW" + " ".join(f" -b {band + 1}" for band in bands)
     translate_opts = " ".join(f" -b {band + 1}" for band in bands)
     if quiet:
         translate_opts += " -q"
+    if compress:
+        translate_opts += " -co compress=LZW"
 
     command = f"gdal_translate {translate_opts} {input_file} {output_file}"
     subprocess.check_call(command, shell=True)

--- a/eogrow/utils/map.py
+++ b/eogrow/utils/map.py
@@ -203,4 +203,5 @@ def extract_bands(
     if quiet:
         translate_opts += " -q"
 
-    subprocess.check_call(f"gdal_translate {translate_opts} {input_file} {output_file}", shell=True)
+    command = f"gdal_translate {translate_opts} {input_file} {output_file}"
+    subprocess.check_call(command, shell=True)

--- a/tests/test_config_files/export_maps/export_maps_data_compressed.json
+++ b/tests/test_config_files/export_maps/export_maps_data_compressed.json
@@ -13,5 +13,5 @@
   "map_dtype": "float32",
   "band_indices": [0],
   "workers": 1,
-  "compress_temporally": true
+  "split_per_timestamp": false
 }

--- a/tests/test_config_files/export_maps/export_maps_mask.json
+++ b/tests/test_config_files/export_maps/export_maps_mask.json
@@ -11,7 +11,7 @@
   "feature": ["mask", "CLM"],
   "map_dtype": "uint16",
   "band_indices": [0],
-  "compress_temporally": true,
+  "split_per_timestamp": false,
   "cogify": true,
   "cogification_resampling": "MODE",
   "workers": 1

--- a/tests/test_config_files/export_maps/export_maps_mask_local_copy.json
+++ b/tests/test_config_files/export_maps/export_maps_mask_local_copy.json
@@ -10,6 +10,7 @@
   "output_folder_key": "maps",
   "feature": ["mask", "CLM"],
   "map_dtype": "uint16",
+  "no_data_value": 0,
   "band_indices": [0],
   "force_local_copies": true,
   "workers": 1


### PR DESCRIPTION
This MR flips the approach of export maps from
1. export
2. merge
3. split temporally
4. cogify

The above approach could only parallelize steps 1 and 4, and we this is `eo-grow` not `eo-die-on-upscaling`, so I switched the order to:
1. export
2. split temporally
3. merge
4. cogify

All steps are now parallelizable (on the head node only so far :/, but that is a x16 speedup for m5.4xlarge).
One of the issues that prevents a very clean parallelization is that in step 2. the jobs need to be grouped input-wise (to avoid possibility of IO blocks) while steps 3 and 4 only make sense if parallel over the temporal axis.

Also due to heavy use of filesystem, a fair amount of refactoring was required to make the methods themselves parallelizable.