### PR TITLE
Update after geopandas 0.12 changes

### DIFF
--- a/eogrow/core/eopatch.py
+++ b/eogrow/core/eopatch.py
@@ -60,7 +60,7 @@ class EOPatchManager(EOGrowObject):
         """
         bbox_grid = self._area_manager.get_grid(add_bbox_column=True)
 
-        bbox_df: DataFrame = pandas.concat(bbox_grid, ignore_index=True)
+        bbox_df: DataFrame = pandas.concat([gdf.drop(columns="geometry") for gdf in bbox_grid], ignore_index=True)
 
         prepared_name_to_id_map = self.generate_names(bbox_df)
         prepared_name_to_bbox_map = dict(zip(prepared_name_to_id_map, bbox_df["BBOX"]))

--- a/tests/test_core/test_eopatch.py
+++ b/tests/test_core/test_eopatch.py
@@ -119,13 +119,11 @@ def test_custom_grid_eopatch_manager(storage):
     assert eopatch_names == ["patch0", "patch1"]
 
 
-@pytest.fixture(name="large_area_manager")
-def large_area_manager_fixture(config_folder, config, storage):
+def test_multi_crs_area(config_folder, config, storage):
+    """Ensures that the eopatch manager works when the area spans multiple CRS zones."""
     filename = os.path.join(config_folder, "other", "large_area_global_config.json")
     area_config = interpret_config_from_path(filename)
     area_manager = UtmZoneAreaManager.from_raw_config(area_config, storage)
-    return EOPatchManager.from_raw_config(config["eopatch"], area_manager)
-
-
-def test_large_area(large_area_manager):
-    large_area_manager.get_eopatch_filenames()
+    patch_manager = EOPatchManager.from_raw_config(config["eopatch"], area_manager)
+    patch_manager.get_eopatch_filenames()
+    patch_manager.get_bboxes()

--- a/tests/test_core/test_eopatch.py
+++ b/tests/test_core/test_eopatch.py
@@ -117,3 +117,15 @@ def test_custom_grid_eopatch_manager(storage):
 
     eopatch_names = eopatch_manager.get_eopatch_filenames()
     assert eopatch_names == ["patch0", "patch1"]
+
+
+@pytest.fixture(name="large_area_manager")
+def large_area_manager_fixture(config_folder, config, storage):
+    filename = os.path.join(config_folder, "other", "large_area_global_config.json")
+    area_config = interpret_config_from_path(filename)
+    area_manager = UtmZoneAreaManager.from_raw_config(area_config, storage)
+    return EOPatchManager.from_raw_config(config["eopatch"], area_manager)
+
+
+def test_large_area(large_area_manager):
+    large_area_manager.get_eopatch_filenames()


### PR DESCRIPTION
The eopatch manager does some shady stuff when the area uses multiple CRS.
Geopandas started complaining in 0.12, so this is a quick fix (with a test) that this should no longer be an issue.