### PR TITLE
Remove old approach to template building as it was never used

### DIFF
--- a/eogrow/cli.py
+++ b/eogrow/cli.py
@@ -10,7 +10,7 @@ from typing import Optional, Tuple
 import click
 
 from .core.config import collect_configs_from_path, decode_config_list, encode_config_list, interpret_config_from_dict
-from .core.schemas import build_minimal_template, build_schema_template
+from .core.schemas import build_schema_template
 from .pipelines.testing import TestPipeline
 from .utils.general import jsonify
 from .utils.meta import collect_schema, import_object, load_pipeline_class
@@ -180,7 +180,7 @@ class EOGrowCli:
     @click.option(
         "--template-format",
         "template_format",
-        type=click.Choice(["minimal", "open-api", "full"], case_sensitive=False),
+        type=click.Choice(["minimal", "open-api"], case_sensitive=False),
         help="Specifies which template format to use. The default is `minimal`",
         default="minimal",
     )
@@ -223,10 +223,8 @@ class EOGrowCli:
 
         if template_format == "open-api":
             template = schema.schema()
-        elif template_format == "full":
-            template = build_schema_template(schema)
         else:
-            template = build_minimal_template(
+            template = build_schema_template(
                 schema,
                 pipeline_import_path=import_path,
                 required_only=required_only,

--- a/tests/test_core/test_schemas.py
+++ b/tests/test_core/test_schemas.py
@@ -4,7 +4,7 @@ Tests for schemas module
 import pytest
 
 from eogrow.core.area import UtmZoneAreaManager
-from eogrow.core.schemas import build_minimal_template, build_schema_template
+from eogrow.core.schemas import build_schema_template
 from eogrow.core.storage import StorageManager
 from eogrow.pipelines.export_maps import ExportMapsPipeline
 from eogrow.pipelines.mapping import MappingPipeline
@@ -14,7 +14,6 @@ pytestmark = pytest.mark.fast
 
 @pytest.mark.fast
 @pytest.mark.parametrize("eogrow_object", [UtmZoneAreaManager, MappingPipeline, ExportMapsPipeline, StorageManager])
-@pytest.mark.parametrize("schema_builder", [build_schema_template, build_minimal_template])
-def test_build_schema_template(eogrow_object, schema_builder):
-    template = schema_builder(eogrow_object.Schema)
+def test_build_schema_template(eogrow_object):
+    template = build_schema_template(eogrow_object.Schema)
     assert isinstance(template, dict)


### PR DESCRIPTION
Less code means less things to go wrong

Also renamed `build_minimal_template` to `build_schema_template` (the name of the old template builder) since it is now THE template, and not the minimal version of it.