### PR TITLE
Reorganize test marks

### DIFF
--- a/tests/test_config_files/global_config.json
+++ b/tests/test_config_files/global_config.json
@@ -25,8 +25,8 @@
     "structure": {
       "data": "data",
       "batch_data": "batch-data",
-      "data_2019": "data-2019",  // these two are custom for testing features pipelines
-      "data_custom_range": "data-custom-range",  // these two are custom for testing features pipelines
+      "data_2019": "data-2019",
+      "data_custom_range": "data-custom-range",
       "data_sampled": "data-sampled",
       "features": "features",
       "features_sampled": "features-sampled",
@@ -34,8 +34,8 @@
       "reference": "reference",
       "models": "models",
       "predictions": "predictions",
+      "predictions_to_map": "predictions_to_map",
       "maps": "maps",
-      "production_maps": "production-maps",
       "temp": "temp" // used by all pipelines whose results do not matter afterwards
     }
   }

--- a/tests/test_config_files/mapping/mapping_pred.json
+++ b/tests/test_config_files/mapping/mapping_pred.json
@@ -1,7 +1,7 @@
 {
   "pipeline": "eogrow.pipelines.mapping.MappingPipeline",
   "**global_config": "${config_path}/../global_config.json",
-  "input_folder_key": "predictions",
+  "input_folder_key": "predictions_to_map",
   "output_folder_key": "temp",
   "input_feature": "PREDICTION_LABELS",
   "output_feature": "PREDICTION_LABELS_MAPPED",

--- a/tests/test_config_files/prediction/prediction.json
+++ b/tests/test_config_files/prediction/prediction.json
@@ -3,7 +3,7 @@
   "**global_config": "${config_path}/../global_config.json",
   "model_folder_key": "models",
   "input_folder_key": "features",
-  "output_folder_key": "predictions",
+  "output_folder_key": "predictions_to_map",
   "output_feature_name": "PREDICTION_LABELS",
   "input_features": [
     ["data", "FEATURES"]

--- a/tests/test_pipelines/test_batch_to_eopatch.py
+++ b/tests/test_pipelines/test_batch_to_eopatch.py
@@ -63,11 +63,10 @@ def prepare_batch_files(
         filesystem.writetext(fs.path.combine(folder, "userdata.json"), json.dumps(userdata))
 
 
-@pytest.mark.chain
 @pytest.mark.parametrize(
     "experiment_name",
     [
-        "batch_to_eopatch",
+        pytest.param("batch_to_eopatch", marks=pytest.mark.chain),
         "batch_to_eopatch_no_userdata",
     ],
 )

--- a/tests/test_pipelines/test_download.py
+++ b/tests/test_pipelines/test_download.py
@@ -13,12 +13,11 @@ def config_folder_fixture(config_folder, stats_folder):
 
 
 @pytest.mark.chain
-@pytest.mark.order(before=["test_download_pipeline", "test_download_step_of_chain"])
+@pytest.mark.order(before=["test_download_pipeline"])
 def test_preparation(storage):
     """Cleans the test project folder"""
 
 
-@pytest.mark.order(before="test_download_step_of_chain")
 @pytest.mark.parametrize(
     "experiment_name",
     [
@@ -30,15 +29,10 @@ def test_preparation(storage):
         "download_custom",
         "download_q3",
         "download_dem",
+        pytest.param("download_l1c_yearly", marks=pytest.mark.chain),
     ],
 )
 def test_download_pipeline(experiment_name, folders):
-    run_and_test_pipeline(experiment_name, **folders)
-
-
-@pytest.mark.chain
-@pytest.mark.parametrize("experiment_name", ["download_l1c_yearly"])
-def test_download_step_of_chain(experiment_name, folders):
     run_and_test_pipeline(experiment_name, **folders)
 
 

--- a/tests/test_pipelines/test_export_maps.py
+++ b/tests/test_pipelines/test_export_maps.py
@@ -12,13 +12,14 @@ def config_folder_fixture(config_folder, stats_folder):
 
 
 @pytest.mark.order(after="test_download.py::test_download_pipeline")
-@pytest.mark.parametrize("experiment_name", ["export_maps_mask", "export_maps_mask_local_copy", "export_maps_data"])
+@pytest.mark.parametrize(
+    "experiment_name",
+    [
+        "export_maps_mask",
+        "export_maps_mask_local_copy",
+        "export_maps_data",
+        pytest.param("export_maps_data_compressed", marks=pytest.mark.chain),
+    ],
+)
 def test_export_maps_pipeline(experiment_name, folders):
-    run_and_test_pipeline(experiment_name, **folders)
-
-
-@pytest.mark.chain
-@pytest.mark.order(after="test_download.py::test_download_step_of_chain")
-@pytest.mark.parametrize("experiment_name", ["export_maps_data_compressed"])
-def test_export_maps_pipeline_in_chain(experiment_name, folders):
     run_and_test_pipeline(experiment_name, **folders)

--- a/tests/test_pipelines/test_features.py
+++ b/tests/test_pipelines/test_features.py
@@ -11,7 +11,7 @@ def config_folder_fixture(config_folder, stats_folder):
     return create_folder_dict(config_folder, stats_folder, "features")
 
 
-@pytest.mark.order(after="test_download.py::test_download_pipeline")
+@pytest.mark.order(after="test_sampling.py::test_sampling_pipeline")
 @pytest.mark.parametrize(
     "experiment_name",
     [
@@ -20,14 +20,8 @@ def config_folder_fixture(config_folder, stats_folder):
         "features_on_rescaled_dn",
         "features_mosaicking",
         "features_dtype",
+        pytest.param("features_on_sampled_data", marks=pytest.mark.chain),
     ],
 )
 def test_features_pipeline(experiment_name, folders):
-    run_and_test_pipeline(experiment_name, **folders)
-
-
-@pytest.mark.chain
-@pytest.mark.order(after="test_sampling.py::test_sampling_chain")
-@pytest.mark.parametrize("experiment_name", ["features_on_sampled_data"])
-def test_features_pipeline_in_chain(experiment_name, folders):
     run_and_test_pipeline(experiment_name, **folders)

--- a/tests/test_pipelines/test_mapping.py
+++ b/tests/test_pipelines/test_mapping.py
@@ -11,14 +11,7 @@ def config_folder_fixture(config_folder, stats_folder):
     return create_folder_dict(config_folder, stats_folder, "mapping")
 
 
-@pytest.mark.chain
-@pytest.mark.order(after=["test_rasterize.py::test_rasterize_pipeline_features"])
-@pytest.mark.parametrize("experiment_name", ["mapping_ref"])
-def test_mapping_pipeline_on_reference_data(experiment_name, folders):
-    run_and_test_pipeline(experiment_name, **folders)
-
-
 @pytest.mark.order(after=["test_prediction.py::test_prediction_pipeline"])
-@pytest.mark.parametrize("experiment_name", ["mapping_pred"])
-def test_mapping_pipeline_on_predictions(experiment_name, folders):
+@pytest.mark.parametrize("experiment_name", ["mapping_ref", pytest.param("mapping_pred", marks=pytest.mark.chain)])
+def test_mapping_pipeline_on_reference_data(experiment_name, folders):
     run_and_test_pipeline(experiment_name, **folders)

--- a/tests/test_pipelines/test_mapping.py
+++ b/tests/test_pipelines/test_mapping.py
@@ -12,6 +12,6 @@ def config_folder_fixture(config_folder, stats_folder):
 
 
 @pytest.mark.order(after=["test_prediction.py::test_prediction_pipeline"])
-@pytest.mark.parametrize("experiment_name", ["mapping_ref", pytest.param("mapping_pred", marks=pytest.mark.chain)])
+@pytest.mark.parametrize("experiment_name", ["mapping_pred", pytest.param("mapping_ref", marks=pytest.mark.chain)])
 def test_mapping_pipeline_on_reference_data(experiment_name, folders):
     run_and_test_pipeline(experiment_name, **folders)

--- a/tests/test_pipelines/test_merge_samples.py
+++ b/tests/test_pipelines/test_merge_samples.py
@@ -12,7 +12,7 @@ def config_folder_fixture(config_folder, stats_folder):
 
 
 @pytest.mark.chain
-@pytest.mark.order(after="test_features.py::test_features_pipeline_in_chain")
+@pytest.mark.order(after="test_features.py::test_features_pipeline")
 @pytest.mark.parametrize(
     "experiment_name, reset_folder",
     [("merge_features_samples", True), ("merge_reference_samples", False)],

--- a/tests/test_pipelines/test_prediction.py
+++ b/tests/test_pipelines/test_prediction.py
@@ -12,13 +12,14 @@ def config_folder_fixture(config_folder, stats_folder):
 
 
 @pytest.mark.order(after="test_training.py::test_training_pipeline_random_split")
-@pytest.mark.parametrize("experiment_name", ["prediction", "prediction_dtype", "prediction_with_encoder"])
+@pytest.mark.parametrize(
+    "experiment_name",
+    [
+        "prediction",
+        "prediction_dtype",
+        "prediction_with_encoder",
+        pytest.param("prediction_chain", marks=pytest.mark.chain),
+    ],
+)
 def test_prediction_pipeline(experiment_name, folders):
-    run_and_test_pipeline(experiment_name, **folders)
-
-
-@pytest.mark.chain
-@pytest.mark.order(after="test_training.py::test_training_pipeline_random_split")
-@pytest.mark.parametrize("experiment_name", ["prediction_chain"])
-def test_prediction_chain(experiment_name, folders):
     run_and_test_pipeline(experiment_name, **folders)

--- a/tests/test_pipelines/test_sampling.py
+++ b/tests/test_pipelines/test_sampling.py
@@ -14,14 +14,13 @@ def config_folder_fixture(config_folder, stats_folder):
 @pytest.mark.order(after="test_rasterize.py::test_rasterize_pipeline")
 @pytest.mark.parametrize(
     "experiment_name",
-    ["sampling_fraction", "sampling_block_number", "sampling_block_fraction", "sampling_grid"],
+    [
+        "sampling_fraction",
+        "sampling_block_number",
+        "sampling_block_fraction",
+        "sampling_grid",
+        pytest.param("sampling_chain", marks=pytest.mark.chain),
+    ],
 )
 def test_sampling_pipeline(experiment_name, folders):
-    run_and_test_pipeline(experiment_name, **folders)
-
-
-@pytest.mark.chain
-@pytest.mark.order(after="test_rasterize.py::test_rasterize_pipeline")
-@pytest.mark.parametrize("experiment_name", ["sampling_chain"])
-def test_sampling_chain(experiment_name, folders):
     run_and_test_pipeline(experiment_name, **folders)

--- a/tests/test_pipelines/test_testing.py
+++ b/tests/test_pipelines/test_testing.py
@@ -14,6 +14,7 @@ def config_folder_fixture(config_folder, stats_folder):
     return create_folder_dict(config_folder, stats_folder, "testing")
 
 
+@pytest.mark.chain
 @pytest.mark.parametrize(
     "experiment_name",
     [

--- a/tests/test_pipelines/test_training.py
+++ b/tests/test_pipelines/test_training.py
@@ -16,11 +16,10 @@ def config_folder_fixture(config_folder, stats_folder):
     return create_folder_dict(config_folder, stats_folder, "training")
 
 
-@pytest.mark.chain
 @pytest.mark.order(after="test_merge_samples.py::test_merge_samples_pipeline")
 @pytest.mark.parametrize(
     "experiment_name, num_classes",
-    [("lgbm_training_no_filter", 6), ("lgbm_training_label_filter", 3)],
+    [pytest.param("lgbm_training_no_filter", 6, marks=pytest.mark.chain), ("lgbm_training_label_filter", 3)],
 )
 def test_training_pipeline_random_split(folders, experiment_name, num_classes):
     config_path = os.path.join(folders["config_folder"], experiment_name + ".json")


### PR DESCRIPTION
reduces code duplication and makes it more obvious which cases are in the chain without additional names