### PR TITLE
Check compatibility of area/eopatch managers for Batch

### DIFF
--- a/eogrow/core/eopatch.py
+++ b/eogrow/core/eopatch.py
@@ -37,7 +37,7 @@ class EOPatchManager(EOGrowObject):
 
         # temporary, until area manager and eopatch manager are merged into a single manager
         if isinstance(area_manager, BatchAreaManager) and not isinstance(self, BatchTileManager):
-            raise ValueError("To use `BatchAreaManager` you should use `BatchTileManager` eopatch manager.")
+            raise ValueError("To use `BatchAreaManager` you should use the `BatchTileManager` eopatch manager.")
 
         self._name_to_id_map: Optional[bidict] = None
         self._name_to_bbox_map: Optional[dict] = None

--- a/eogrow/core/eopatch.py
+++ b/eogrow/core/eopatch.py
@@ -35,6 +35,10 @@ class EOPatchManager(EOGrowObject):
 
         self._area_manager = area_manager
 
+        # temporary, until area manager and eopatch manager are merged into a single manager
+        if isinstance(area_manager, BatchAreaManager) and not isinstance(self, BatchTileManager):
+            raise ValueError("To use `BatchAreaManager` you should use `BatchTileManager` eopatch manager.")
+
         self._name_to_id_map: Optional[bidict] = None
         self._name_to_bbox_map: Optional[dict] = None
 

--- a/tests/test_core/test_eopatch.py
+++ b/tests/test_core/test_eopatch.py
@@ -4,8 +4,9 @@ from tempfile import NamedTemporaryFile
 import pytest
 
 from eogrow.core.area import CustomGridAreaManager, UtmZoneAreaManager
+from eogrow.core.area.batch import BatchAreaManager
 from eogrow.core.config import interpret_config_from_dict, interpret_config_from_path
-from eogrow.core.eopatch import CustomGridEOPatchManager, EOPatchManager
+from eogrow.core.eopatch import BatchTileManager, CustomGridEOPatchManager, EOPatchManager
 
 pytestmark = pytest.mark.fast
 
@@ -127,3 +128,12 @@ def test_multi_crs_area(config_folder, config, storage):
     patch_manager = EOPatchManager.from_raw_config(config["eopatch"], area_manager)
     patch_manager.get_eopatch_filenames()
     patch_manager.get_bboxes()
+
+
+def test_compatibility_check(config_folder, config, storage):
+    filename = os.path.join(config_folder, "other", "batch_area_config.json")
+    batch_config = interpret_config_from_path(filename)
+    area_manager = BatchAreaManager.from_raw_config(batch_config, storage)
+    with pytest.raises(ValueError):
+        EOPatchManager.from_raw_config(config["eopatch"], area_manager)
+    BatchTileManager.from_raw_config(config["eopatch"], area_manager)


### PR DESCRIPTION
It is already checked one way (batch eopatch can only be used with batch area) but it often happens that one uses batch area but not batch eopatch manager. The code fails at the end of the batch download (kinda shitty).

This is a temporary hack that checks the compatibility until eopatch and area managers are reworked.