### PR TITLE
Streamline module-level docstrings

### DIFF
--- a/eogrow/cli.py
+++ b/eogrow/cli.py
@@ -1,6 +1,4 @@
-"""
-Module implementing command line interface for `eo-grow`
-"""
+"""Implements the command line interface for `eo-grow`."""
 import json
 import os
 import re

--- a/eogrow/core/area/base.py
+++ b/eogrow/core/area/base.py
@@ -1,6 +1,4 @@
-"""
-A base AreaManager implementation
-"""
+"""Implementation of the base AreaManager."""
 import logging
 from collections import defaultdict
 from typing import Any, List, Optional

--- a/eogrow/core/area/batch.py
+++ b/eogrow/core/area/batch.py
@@ -1,6 +1,4 @@
-"""
-Area managers for Sentinel Hub batch grids
-"""
+"""Area manager implementation for Sentinel Hub batch grids."""
 import contextlib
 import warnings
 from typing import Any, List, Tuple, cast

--- a/eogrow/core/area/custom_grid.py
+++ b/eogrow/core/area/custom_grid.py
@@ -1,6 +1,4 @@
-"""
-For working with pre-defined grids
-"""
+"""Area manager implementation for custom grids."""
 import logging
 from typing import Any, List
 

--- a/eogrow/core/area/utm.py
+++ b/eogrow/core/area/utm.py
@@ -1,6 +1,4 @@
-"""
-Area managers working with UTM CRS
-"""
+"""Area manager implementation for automated UTM CRS grids."""
 import logging
 from typing import Any, List, Tuple, cast
 

--- a/eogrow/core/config.py
+++ b/eogrow/core/config.py
@@ -1,6 +1,4 @@
-"""
-Module implementing management of configurations
-"""
+"""Implements functions that transform raw dictionaries/JSON files according to the config language of eo-grow."""
 import base64
 import copy
 import json

--- a/eogrow/core/eopatch.py
+++ b/eogrow/core/eopatch.py
@@ -1,6 +1,4 @@
-"""
-Module for handling EOPatch naming conventions
-"""
+"""Module for EOPatchManager that handles EOPatch naming conventions."""
 import json
 import os
 import warnings

--- a/eogrow/core/logging.py
+++ b/eogrow/core/logging.py
@@ -1,6 +1,4 @@
-"""
-Module with utilities for logging
-"""
+"""Implementation of LoggingManager and different handlers used for logging."""
 import contextlib
 import json
 import logging

--- a/eogrow/core/pipeline.py
+++ b/eogrow/core/pipeline.py
@@ -1,6 +1,4 @@
-"""
-Module where base Pipeline class is implemented
-"""
+"""Implementation of the base Pipeline class."""
 import datetime as dt
 import logging
 import time

--- a/eogrow/core/storage.py
+++ b/eogrow/core/storage.py
@@ -1,6 +1,4 @@
-"""
-This module handles everything regarding storage of the data
-"""
+"""Implementation of the StorageManager class for handling project storage."""
 from typing import Dict, Literal, Optional
 
 import fs

--- a/eogrow/pipelines/batch_to_eopatch.py
+++ b/eogrow/pipelines/batch_to_eopatch.py
@@ -1,6 +1,4 @@
-"""
-Conversion of batch results to EOPatches
-"""
+"""Pipeline for conversion of batch results to EOPatches."""
 from typing import Any, Dict, List, Optional
 
 import numpy as np

--- a/eogrow/pipelines/byoc.py
+++ b/eogrow/pipelines/byoc.py
@@ -1,6 +1,4 @@
-"""
-Defines pipelines for ingesting and modifying BYOC collections.
-"""
+"""Defines pipelines for ingesting and modifying BYOC collections."""
 import datetime
 import datetime as dt
 import logging

--- a/eogrow/pipelines/download.py
+++ b/eogrow/pipelines/download.py
@@ -1,6 +1,4 @@
-"""
-Module implementing pipelines for downloading data
-"""
+"""Implements different customizeable pipelines for downloading data."""
 import abc
 import datetime as dt
 import logging

--- a/eogrow/pipelines/download_batch.py
+++ b/eogrow/pipelines/download_batch.py
@@ -1,6 +1,4 @@
-"""
-Download pipeline that works with Sentinel Hub batch service
-"""
+"""Download pipeline that works with Sentinel Hub batch service."""
 import logging
 from typing import Any, DefaultDict, Dict, List, Literal, Optional, Tuple
 

--- a/eogrow/pipelines/export_maps.py
+++ b/eogrow/pipelines/export_maps.py
@@ -1,6 +1,4 @@
-"""
-Module implementing export_maps pipelines
-"""
+"""Implements a pipeline for exporting data to TIFF files, can be used to prepare BYOC tiles."""
 import datetime as dt
 import itertools as it
 import logging

--- a/eogrow/pipelines/features.py
+++ b/eogrow/pipelines/features.py
@@ -1,6 +1,4 @@
-"""
-A pipeline to construct features for training/prediction
-"""
+"""Implements a pipeline to construct features for training/prediction."""
 import logging
 from typing import Dict, List, Optional, Tuple
 

--- a/eogrow/pipelines/mapping.py
+++ b/eogrow/pipelines/mapping.py
@@ -1,6 +1,4 @@
-"""
-Pipelines that transform data
-"""
+"""Implements a simple pipeline for mapping data according to a dictionary."""
 from typing import Dict, List
 
 from pydantic import Field

--- a/eogrow/pipelines/merge_samples.py
+++ b/eogrow/pipelines/merge_samples.py
@@ -1,6 +1,4 @@
-"""
-Module implementing merge samples
-"""
+"""Implements a pipeline for merging sampled features into numpy arrays fit for training models."""
 import logging
 from typing import List, Literal, Optional, Tuple, cast
 

--- a/eogrow/pipelines/prediction.py
+++ b/eogrow/pipelines/prediction.py
@@ -1,6 +1,4 @@
-"""
-Module implementing prediction pipeline
-"""
+"""Implements a base prediction pipeline and a LGBM specialized classification and regression pipelines."""
 import abc
 from typing import List, Optional, Tuple
 

--- a/eogrow/pipelines/rasterize.py
+++ b/eogrow/pipelines/rasterize.py
@@ -1,6 +1,4 @@
-"""
-A pipeline module for rasterizing vector datasets.
-"""
+"""Implements a pipeline for rasterizing vector datasets."""
 import logging
 import os
 import uuid

--- a/eogrow/pipelines/sampling.py
+++ b/eogrow/pipelines/sampling.py
@@ -1,6 +1,4 @@
-"""
-Module implementing sampling pipelines
-"""
+"""Implements different pipelines for sampling from data."""
 import abc
 from typing import Any, Dict, List, Optional, Tuple, Union
 

--- a/eogrow/pipelines/switch_grids.py
+++ b/eogrow/pipelines/switch_grids.py
@@ -1,6 +1,4 @@
-"""
-Pipelines for testing
-"""
+"""Implements a pipeline that allows switching between two AreaManagers."""
 import logging
 from typing import Any, Dict, List, Literal, Optional, Tuple
 

--- a/eogrow/pipelines/testing.py
+++ b/eogrow/pipelines/testing.py
@@ -1,6 +1,4 @@
-"""
-Pipelines for testing
-"""
+"""Implements pipelines used for data preparation in testing."""
 import logging
 from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar
 

--- a/eogrow/pipelines/training.py
+++ b/eogrow/pipelines/training.py
@@ -1,6 +1,5 @@
-"""
-Module implementing pipelines for training an ML classifier
-"""
+"""Implements a base training pipeline and a LGBM specialized classification and regression model training pipelines."""
+
 import abc
 import logging
 from typing import Any, Dict, List, Literal, Optional, Tuple

--- a/eogrow/tasks/batch_to_eopatch.py
+++ b/eogrow/tasks/batch_to_eopatch.py
@@ -1,6 +1,4 @@
-"""
-Tasks used to transform Sentinel Hub Batch results into EOPatches
-"""
+"""Tasks used to transform Sentinel Hub Batch results into EOPatches."""
 import concurrent.futures
 import json
 from typing import List, Optional

--- a/eogrow/tasks/common.py
+++ b/eogrow/tasks/common.py
@@ -1,6 +1,4 @@
-"""
-Common tasks shared between pipelines
-"""
+"""Common tasks shared between pipelines."""
 from typing import Callable, List, Optional, Union
 
 import numpy as np
@@ -28,9 +26,7 @@ class MappingTask(MapFeatureTask):
 
 
 class ClassFilterTask(EOTask):
-    """
-    Run class specific morphological operation.
-    """
+    """Run class specific morphological operation."""
 
     def __init__(
         self,

--- a/eogrow/tasks/features.py
+++ b/eogrow/tasks/features.py
@@ -1,6 +1,4 @@
-"""
-Definition of tasks needed for calculating features
-"""
+"""Implements tasks needed for calculating features in FeaturesPipeline."""
 import abc
 from datetime import date, datetime, time, timedelta
 from typing import List, Optional, Sequence, Tuple, Union

--- a/eogrow/tasks/prediction.py
+++ b/eogrow/tasks/prediction.py
@@ -1,6 +1,4 @@
-"""
-Task definitions for prediction
-"""
+"""Defines task needed in prediction pipelines."""
 import abc
 from typing import Any, Callable, List, Optional, Tuple, Union, cast
 

--- a/eogrow/tasks/spatial.py
+++ b/eogrow/tasks/spatial.py
@@ -1,6 +1,4 @@
-"""
-Tasks for spatial operations on EOPatches
-"""
+"""Tasks for spatial operations on EOPatches, used in grid-switching."""
 from typing import Dict, List, Optional, Tuple, Union, cast
 
 import numpy as np

--- a/eogrow/tasks/testing.py
+++ b/eogrow/tasks/testing.py
@@ -1,6 +1,4 @@
-"""
-Implements tasks for testing purposes
-"""
+"""Tasks used to generate test data."""
 import datetime as dt
 from typing import Optional, Tuple, Union
 

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -1,5 +1,3 @@
-""" A module for testing eogrow.config
-"""
 import json
 import os
 

--- a/tests/test_core/test_logging.py
+++ b/tests/test_core/test_logging.py
@@ -1,6 +1,3 @@
-"""
-Tests for logging module
-"""
 import functools
 
 import boto3

--- a/tests/test_core/test_pipeline.py
+++ b/tests/test_core/test_pipeline.py
@@ -1,6 +1,3 @@
-"""
-Testing basic pipeline functionalities
-"""
 import logging
 import os
 

--- a/tests/test_core/test_schemas.py
+++ b/tests/test_core/test_schemas.py
@@ -1,6 +1,3 @@
-"""
-Tests for schemas module
-"""
 import pytest
 
 from eogrow.core.area import UtmZoneAreaManager

--- a/tests/test_core/test_storage.py
+++ b/tests/test_core/test_storage.py
@@ -1,5 +1,3 @@
-""" A module for testing StorageManager class
-"""
 import os
 from typing import Optional
 

--- a/tests/test_pipelines/test_batch_to_eopatch.py
+++ b/tests/test_pipelines/test_batch_to_eopatch.py
@@ -1,6 +1,3 @@
-"""
-Testing batch-to-eopatch pipeline
-"""
 import json
 import os
 from typing import Iterable, Optional

--- a/tests/test_pipelines/test_download.py
+++ b/tests/test_pipelines/test_download.py
@@ -1,6 +1,3 @@
-"""
-Unit tests for DownloadPipeline
-"""
 import pytest
 from pydantic import ValidationError
 

--- a/tests/test_pipelines/test_export_maps.py
+++ b/tests/test_pipelines/test_export_maps.py
@@ -1,6 +1,3 @@
-"""
-Testing pipeline for exporting maps
-"""
 import pytest
 
 from eogrow.utils.testing import create_folder_dict, run_and_test_pipeline

--- a/tests/test_pipelines/test_features.py
+++ b/tests/test_pipelines/test_features.py
@@ -1,6 +1,3 @@
-"""
-Unit tests for FeaturesPipeline
-"""
 import pytest
 
 from eogrow.utils.testing import create_folder_dict, run_and_test_pipeline

--- a/tests/test_pipelines/test_import_tiff.py
+++ b/tests/test_pipelines/test_import_tiff.py
@@ -1,6 +1,3 @@
-"""
-Testing batch-to-eopatch pipeline
-"""
 import os
 
 import numpy as np

--- a/tests/test_pipelines/test_mapping.py
+++ b/tests/test_pipelines/test_mapping.py
@@ -1,6 +1,3 @@
-"""
-Tests for prediction pipeline
-"""
 import pytest
 
 from eogrow.utils.testing import create_folder_dict, run_and_test_pipeline

--- a/tests/test_pipelines/test_merge_samples.py
+++ b/tests/test_pipelines/test_merge_samples.py
@@ -1,6 +1,3 @@
-"""
-Testing merging pipeline
-"""
 import pytest
 
 from eogrow.utils.testing import create_folder_dict, run_and_test_pipeline

--- a/tests/test_pipelines/test_prediction.py
+++ b/tests/test_pipelines/test_prediction.py
@@ -1,6 +1,3 @@
-"""
-Tests for prediction pipeline
-"""
 import pytest
 
 from eogrow.utils.testing import create_folder_dict, run_and_test_pipeline

--- a/tests/test_pipelines/test_rasterize.py
+++ b/tests/test_pipelines/test_rasterize.py
@@ -1,6 +1,3 @@
-"""
-Testing rasterization pipeline
-"""
 import os
 
 import geopandas as gpd

--- a/tests/test_pipelines/test_sampling.py
+++ b/tests/test_pipelines/test_sampling.py
@@ -1,6 +1,3 @@
-"""
-Unit tests for sampling pipeline
-"""
 import pytest
 
 from eogrow.utils.testing import create_folder_dict, run_and_test_pipeline

--- a/tests/test_pipelines/test_switch_grids.py
+++ b/tests/test_pipelines/test_switch_grids.py
@@ -1,6 +1,3 @@
-"""
-Tests for grid switching
-"""
 import os
 import shutil
 

--- a/tests/test_pipelines/test_testing.py
+++ b/tests/test_pipelines/test_testing.py
@@ -1,7 +1,3 @@
-"""
-Tests for testing pipelines
-"""
-
 import pytest
 
 from eogrow.utils.testing import create_folder_dict, run_and_test_pipeline

--- a/tests/test_pipelines/test_training.py
+++ b/tests/test_pipelines/test_training.py
@@ -1,6 +1,3 @@
-"""
-Testing training pipelines
-"""
 import os
 
 import joblib

--- a/tests/test_utils/test_filter.py
+++ b/tests/test_utils/test_filter.py
@@ -1,6 +1,3 @@
-"""
-Tests for fs_utils module
-"""
 import datetime
 from itertools import chain, combinations
 

--- a/tests/test_utils/test_fs.py
+++ b/tests/test_utils/test_fs.py
@@ -1,6 +1,3 @@
-"""
-Tests for fs_utils module
-"""
 import json
 import os
 

--- a/tests/test_utils/test_general.py
+++ b/tests/test_utils/test_general.py
@@ -1,6 +1,3 @@
-"""
-Tests for general utilities
-"""
 import datetime as dt
 import enum
 import json

--- a/tests/test_utils/test_grid.py
+++ b/tests/test_utils/test_grid.py
@@ -1,6 +1,3 @@
-"""
-Tests of grid utilities
-"""
 import random
 
 import pytest

--- a/tests/test_utils/test_map.py
+++ b/tests/test_utils/test_map.py
@@ -1,6 +1,3 @@
-"""
-Tests for utils.map module
-"""
 from typing import List, Optional
 
 import numpy as np

--- a/tests/test_utils/test_ray.py
+++ b/tests/test_utils/test_ray.py
@@ -1,6 +1,3 @@
-"""
-Tests for ray utilities
-"""
 import pytest
 import ray
 

--- a/tests/test_utils/test_validators.py
+++ b/tests/test_utils/test_validators.py
@@ -1,6 +1,3 @@
-"""
-Tests for validator utilities
-"""
 import datetime as dt
 from contextlib import nullcontext
 from typing import Optional, Union


### PR DESCRIPTION
Recently noticed that most of the module level docstrings are garbage.

1. Removed module level docstrings in tests (except when they explain something about the tests) because it makes no sense to have a `test_rasterization_pipeline.py` file contain `"""Tests rasterization pipeline"""`
2. For modules that contain package code I left the docstrings (although they are mostly useless) for the purpose of docs. In such cases I streamlined the one-liners a bit to have them more consistent. Also fixed all the wrong ones (copy paste artefacts).