### PR TITLE
Enable codecov upload

### DIFF
--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -104,11 +104,6 @@ jobs:
             --sh_client_secret "${{ secrets.SH_CLIENT_SECRET }}"
           pytest -m "fast or chain" --cov --cov-report=term --cov-report=xml
 
-      - name: Run reduced tests
-        if: ${{ !matrix.full_test_suite }}
-        run: |
-          pytest -m "not sh_integration"
-
       - name: Upload code coverage
         if: ${{ matrix.full_test_suite }}
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -102,8 +102,20 @@ jobs:
           sentinelhub.config \
             --sh_client_id "${{ secrets.SH_CLIENT_ID }}" \
             --sh_client_secret "${{ secrets.SH_CLIENT_SECRET }}"
-          pytest -m "fast"
-          pytest -m "chain"
+          pytest -m "fast or chain" --cov --cov-report=term --cov-report=xml
+
+      - name: Run reduced tests
+        if: ${{ !matrix.full_test_suite }}
+        run: |
+          pytest -m "not sh_integration"
+
+      - name: Upload code coverage
+        if: ${{ matrix.full_test_suite }}
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml
+          fail_ci_if_error: true
+          verbose: false
 
   mirror-to-gitlab:
     if: github.event_name == 'push'

--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -96,7 +96,7 @@ jobs:
         run: |
           pytest -m "fast"
 
-      - name: Run fast and chain integration tests
+      - name: Run fast and chain integration tests, create code coverage
         if: ${{ matrix.full_test_suite }}
         run: |
           sentinelhub.config \

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License](https://img.shields.io/pypi/l/eo-grow.svg)](https://github.com/sentinel-hub/eo-grow/blob/master/LICENSE)
 [![Overall downloads](http://pepy.tech/badge/eo-grow)](https://pepy.tech/project/eo-grow)
 [![Last month downloads](https://pepy.tech/badge/eo-grow/month)](https://pepy.tech/project/eo-grow)
+[![Code coverage](https://codecov.io/gh/sentinel-hub/eo-grow/branch/main/graph/badge.svg)](https://codecov.io/gh/sentinel-hub/eo-grow)
 
 # eo-grow
 **Earth observation framework for scaled-up processing in Python.**

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ moto
 mypy>=0.990
 pre-commit
 pytest>=4.0.0
+pytest-cov
 pytest-lazy-fixture
 pytest-order
 requests-mock


### PR DESCRIPTION
Should help us identify weak spots in tests, although it cannot follow tests in deep into eo-learn (so we can't see if we covered all edge-case configurations of a pipeline)