### PR TITLE
Define new BaseAreaManager and create custom grid version of it

### DIFF
--- a/eogrow/core/area/__init__.py
+++ b/eogrow/core/area/__init__.py
@@ -3,5 +3,5 @@ A subfolder for area management
 """
 
 from .batch import BatchAreaManager
-from .custom_grid import CustomGridAreaManager
+from .custom_grid import CustomGridAreaManager, NewCustomGridAreaManager
 from .utm import UtmZoneAreaManager

--- a/eogrow/core/area/base.py
+++ b/eogrow/core/area/base.py
@@ -277,11 +277,8 @@ class BaseAreaManager(EOGrowObject, metaclass=ABCMeta):
     def get_grid(self) -> Dict[CRS, gpd.GeoDataFrame]:
         """Provides a grid of bounding boxes which divide the AOI. Uses caching to avoid recalculations.
 
-        The grid is split into different CRS zones.
-
-        The `geometry` column serves as BBox geometry definition. The `geom.bounds` is taken as the definition.
-
-        The EOPatch names are stored in a column with identifier `self.NAME_COLUMN`.
+        The grid is split into different CRS zones. The `bounds` properties of the geometries are taken as BBox
+        definitions. EOPatch names are stored in a column with identifier `self.NAME_COLUMN`.
 
         :return: A dictionary of GeoDataFrames that defines how the area is split into EOPatches.
         """
@@ -298,12 +295,8 @@ class BaseAreaManager(EOGrowObject, metaclass=ABCMeta):
     def _create_grid(self) -> Dict[CRS, gpd.GeoDataFrame]:
         """Defines a new grid, which encodes how the area is split into EOPatches.
 
-        The grid is split into different CRS zones.
-
-        The `geometry` column serves as BBox geometry definition, with the implication that for a geometry `geom`
-        the BBox is defined as `geom.bounds`.
-
-        The EOPatch names are stored in a column with identifier `eopatch_name`.
+        The grid is split into different CRS zones. The `bounds` properties of the geometries are taken as BBox
+        definitions. EOPatch names are stored in a column with identifier `self.NAME_COLUMN`.
         """
 
     def _load_grid(self, grid_path: str) -> Dict[CRS, gpd.GeoDataFrame]:

--- a/eogrow/core/area/base.py
+++ b/eogrow/core/area/base.py
@@ -272,7 +272,7 @@ class BaseAreaManager(EOGrowObject, metaclass=ABCMeta):
 
     @abstractmethod
     def get_area_geometry(self, *, crs: CRS = CRS.WGS84) -> Geometry:
-        """Provides a single geometry object of entire AOI"""
+        """Provides a dissolved geometry object of the entire AOI"""
 
     def get_grid(self) -> Dict[CRS, gpd.GeoDataFrame]:
         """Provides a grid of bounding boxes which divide the AOI. Uses caching to avoid recalculations.

--- a/eogrow/core/area/custom_grid.py
+++ b/eogrow/core/area/custom_grid.py
@@ -120,7 +120,7 @@ class NewCustomGridAreaManager(BaseAreaManager):
         return Geometry(area_shape, crs)
 
     def get_grid_cache_filename(self) -> str:
-        input_filename = self.config.grid_filename.rsplit(".", 1)[0]
         input_filename = fs.path.basename(self.config.grid_filename)
+        input_filename = input_filename.rsplit(".", 1)[0]
 
         return f"{self.__class__.__name__}_{input_filename}.gpkg"

--- a/eogrow/core/area/custom_grid.py
+++ b/eogrow/core/area/custom_grid.py
@@ -1,6 +1,6 @@
 """Area manager implementation for custom grids."""
 import logging
-from typing import Any, List
+from typing import Any, Dict, List
 
 import fs
 import geopandas as gpd
@@ -12,7 +12,7 @@ from sentinelhub import CRS, Geometry
 from ...utils.types import Path
 from ...utils.vector import concat_gdf
 from ..schemas import ManagerSchema
-from .base import AreaManager
+from .base import AreaManager, BaseAreaManager
 
 LOGGER = logging.getLogger(__name__)
 
@@ -81,3 +81,46 @@ class CustomGridAreaManager(AreaManager):
         filename = filename.replace(" ", "_")
 
         return fs.path.combine(self.storage.get_cache_folder(), f"{filename}.{suffix}")
+
+
+class NewCustomGridAreaManager(BaseAreaManager):
+    """Area manager that works with a pre-defined grid of EOPatches"""
+
+    class Schema(BaseAreaManager.Schema):
+        grid_folder_key: str = Field("input_data", description="Which folder the grid file is in.")
+        grid_filename: Path = Field(
+            description=(
+                "A Geopackage with a collection of bounding boxes and attributes that will define EOPatches. In"
+                " case bounding boxes are in multiple CRS then each Geopackage layer should contain bounding boxes"
+                " from one CRS."
+            ),
+            regex=r"^.+\..+$",
+        )
+        name_column: str = Field(description="Name of the column containing EOPatch names.")
+
+    config: Schema
+
+    def _create_grid(self) -> Dict[CRS, gpd.GeoDataFrame]:
+        grid_path = fs.path.combine(self.storage.get_folder(self.config.grid_folder_key), self.config.grid_filename)
+        grid = self._load_grid(grid_path)
+
+        for crs, crs_gdf in grid.items():
+            # Correct name of eoptach-name-column, drop all non-significant ones
+            names = crs_gdf[self.config.name_column]
+            grid[crs] = gpd.GeoDataFrame(geometry=crs_gdf.geometry, data={self.NAME_COLUMN: names}, crs=crs_gdf.crs)
+
+        return grid
+
+    def get_area_geometry(self, *, crs: CRS = CRS.WGS84) -> Geometry:
+        all_grid_gdfs = list(self.get_grid().values())
+        area_df = concat_gdf(all_grid_gdfs, reproject_crs=crs)
+
+        LOGGER.info("Calculating a unary union of the area geometries")
+        area_shape = shapely.ops.unary_union(area_df.geometry)
+        return Geometry(area_shape, crs)
+
+    def get_grid_cache_filename(self) -> str:
+        input_filename = self.config.grid_filename.rsplit(".", 1)[0]
+        input_filename = fs.path.basename(self.config.grid_filename)
+
+        return f"{self.__class__.__name__}_{input_filename}.gpkg"

--- a/tests/test_core/test_area/test_custom_grid.py
+++ b/tests/test_core/test_area/test_custom_grid.py
@@ -3,7 +3,7 @@ from geopandas import GeoDataFrame
 
 from sentinelhub import CRS, BBox, Geometry
 
-from eogrow.core.area import CustomGridAreaManager
+from eogrow.core.area import CustomGridAreaManager, NewCustomGridAreaManager
 from eogrow.core.config import interpret_config_from_dict
 
 pytestmark = pytest.mark.fast
@@ -23,6 +23,27 @@ def test_custom_grid_area_manager(storage):
     assert gdf.crs.to_epsg() == 32638
     assert len(gdf.index) == 2
     assert gdf.BBOX.values[0] == BBox((729480.0, 4390045.0, 732120.0, 4391255.0), CRS.UTM_38N)
+
+    geometry = manager.get_area_geometry(crs=CRS.UTM_38N)
+    assert geometry == Geometry(
+        "POLYGON ((729480 4391145, 729480 4391255, 729480 4392355, 732120 4392355, 732120 4391255, 732120 4391145, "
+        "732120 4390045, 729480 4390045, 729480 4391145))",
+        crs=CRS.UTM_38N,
+    )
+
+
+def test_new_custom_grid_area_manager(storage):
+    config = interpret_config_from_dict({"grid_filename": "test_custom_grid.geojson", "name_column": "name"})
+    manager = NewCustomGridAreaManager.from_raw_config(config, storage)
+
+    grid = manager.get_grid()
+    assert len(grid) == 1
+
+    gdf = grid[CRS.UTM_38N]
+    assert gdf.crs.to_epsg() == 32638
+    assert len(gdf.index) == 2
+    name_to_geom = {row.eopatch_name: row.geometry for _, row in gdf.iterrows()}
+    assert name_to_geom["patch0"].bounds == (729480.0, 4390045.0, 732120.0, 4391255.0)
 
     geometry = manager.get_area_geometry(crs=CRS.UTM_38N)
     assert geometry == Geometry(

--- a/tests/test_core/test_area/test_custom_grid.py
+++ b/tests/test_core/test_area/test_custom_grid.py
@@ -51,3 +51,5 @@ def test_new_custom_grid_area_manager(storage):
         "732120 4390045, 729480 4390045, 729480 4391145))",
         crs=CRS.UTM_38N,
     )
+
+    assert manager.get_grid_cache_filename() == "NewCustomGridAreaManager_test_custom_grid.gpkg"


### PR DESCRIPTION
In order to keep chunks smaller, i'll add them in such small updated.

For now I focused on supporting the bare minimum, and things will only be added if there is no better way of doing it.
I decided to transition grids from lists to dictionaries, because it is now impossible to have two grid files for the same CRS.

the biggest issue I have is how to name the column with eopatch names in the grid representation. I was considering just fixing it to `eopatch_name` so that the rest of the code does not need to use `self.area_manager.NAMES_COLUMN`