### PR TITLE
Add eopatch manager functionality to area manager

### DIFF
--- a/eogrow/core/area/base.py
+++ b/eogrow/core/area/base.py
@@ -2,7 +2,7 @@
 import logging
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
-from typing import Dict, List, Literal, Optional
+from typing import Dict, Iterable, List, Literal, Optional, Tuple
 
 import fiona
 import fs
@@ -346,6 +346,19 @@ class BaseAreaManager(EOGrowObject, metaclass=ABCMeta):
 
         Should ensure that two different grids don't clash.
         """
+
+    def get_names_and_bboxes(self, relevant_patches: Optional[Iterable[str]] = None) -> List[Tuple[str, BBox]]:
+        """Returns a list of eopatch names and appropriate BBoxes.
+
+        :param relevant_patches: A collection of patch names for which BBoxes should be returned.
+        """
+        to_return = set(relevant_patches) if relevant_patches is not None else None
+        all_patches = []
+        for crs, grid in self.get_grid().items():
+            for _, row in grid.iterrows():
+                if to_return is None or row.eopatch_name in to_return:
+                    all_patches.append((row.eopatch_name, BBox(row.geometry.bounds, crs=crs)))
+        return all_patches
 
 
 def get_geometry_from_file(

--- a/eogrow/core/logging.py
+++ b/eogrow/core/logging.py
@@ -14,6 +14,7 @@ from pydantic import Field
 
 from eolearn.core.utils.fs import join_path, unpickle_fs
 
+from ..utils.eopatch_list import save_eopatch_names
 from ..utils.fs import LocalFile
 from ..utils.general import jsonify
 from ..utils.logging import get_instance_info
@@ -223,13 +224,9 @@ class LoggingManager(EOGrowObject):
         if not self.config.save_logs:
             return
 
-        filesystem = self.storage.filesystem
         logs_folder = self.get_pipeline_logs_folder(pipeline_execution_name)
-
         for eopatches, filename in [(finished, "finished.json"), (failed, "failed.json")]:
-            path = fs.path.combine(logs_folder, filename)
-            with filesystem.open(path, "w") as file:
-                json.dump(eopatches, file, indent=2)
+            save_eopatch_names(self.storage.filesystem, fs.path.combine(logs_folder, filename), eopatches)
 
 
 class FilesystemHandler(FileHandler):

--- a/eogrow/utils/eopatch_list.py
+++ b/eogrow/utils/eopatch_list.py
@@ -1,8 +1,8 @@
 """Utilities for working with lists of EOPatch names."""
 
+import json
 from typing import List
 
-import rapidjson
 from fs.base import FS
 
 
@@ -14,8 +14,8 @@ def save_eopatch_names(filesystem: FS, file_path: str, eopatch_list: List[str]) 
     :param eopatch_list: A list of EOPatch names.
     """
 
-    with filesystem.openbin(file_path, "w") as file:
-        rapidjson.dump(eopatch_list, file, indent=2)
+    with filesystem.open(file_path, "w") as file:
+        json.dump(eopatch_list, file, indent=2)
 
 
 def load_eopatch_names(filesystem: FS, file_path: str) -> List[str]:
@@ -25,5 +25,5 @@ def load_eopatch_names(filesystem: FS, file_path: str) -> List[str]:
     :param filename: Path of a JSON file where names of EOPatches are saved.
     :return: A list of EOPatch names loaded from file.
     """
-    with filesystem.openbin(file_path, "w") as file:
-        return rapidjson.load(file)
+    with filesystem.open(file_path, "r") as file:
+        return json.load(file)

--- a/eogrow/utils/eopatch_list.py
+++ b/eogrow/utils/eopatch_list.py
@@ -1,0 +1,29 @@
+"""Utilities for working with lists of EOPatch names."""
+
+from typing import List
+
+import rapidjson
+from fs.base import FS
+
+
+def save_eopatch_names(filesystem: FS, file_path: str, eopatch_list: List[str]) -> None:
+    """Saves a list of EOPatches to a file
+
+    :param filesystem: Filesystem used to save the file.
+    :param filename: Path of a JSON file where names of EOPatches will be saved.
+    :param eopatch_list: A list of EOPatch names.
+    """
+
+    with filesystem.openbin(file_path, "w") as file:
+        rapidjson.dump(eopatch_list, file, indent=2)
+
+
+def load_eopatch_names(filesystem: FS, file_path: str) -> List[str]:
+    """Loads a list of EOPatch names from a file
+
+    :param filesystem: Filesystem used to load the file.
+    :param filename: Path of a JSON file where names of EOPatches are saved.
+    :return: A list of EOPatch names loaded from file.
+    """
+    with filesystem.openbin(file_path, "w") as file:
+        return rapidjson.load(file)

--- a/tests/test_config_files/other/local_storage_test.json
+++ b/tests/test_config_files/other/local_storage_test.json
@@ -11,6 +11,7 @@
     "project_folder": "${config_path}/../../test_project/",
     "aws_profile": null,
     "structure": {
+      "temp": "temp",
       "batch": "tiffs",
       "eopatches": "path/to/eopatches"
     }

--- a/tests/test_core/test_area/test_base.py
+++ b/tests/test_core/test_area/test_base.py
@@ -10,6 +10,7 @@ from sentinelhub import CRS, BBox
 from sentinelhub.geometry import Geometry
 
 from eogrow.core.area.base import BaseAreaManager, get_geometry_from_file
+from eogrow.utils.eopatch_list import save_eopatch_names
 from eogrow.utils.vector import count_points
 
 pytestmark = pytest.mark.fast
@@ -62,9 +63,16 @@ def test_get_grid_caching(storage):
     ],
 )
 def test_get_names_and_bboxes(patch_list, expected_bboxes, storage):
-    manager = DummyAreaManager.from_raw_config({}, storage)
+    if patch_list is None:
+        config = {}
+    else:
+        path = fs.path.join(storage.get_folder("temp"), "patch_list.json")
+        save_eopatch_names(storage.filesystem, path, patch_list)
+        config = {"patch_list": {"input_folder_key": "temp", "filename": "patch_list.json"}}
 
-    assert expected_bboxes == manager.get_names_and_bboxes(patch_list)
+    manager = DummyAreaManager.from_raw_config(config, storage)
+
+    assert expected_bboxes == manager.get_names_and_bboxes()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
adds patch list functionality as part of the area manager

area managers can now output named bboxes, which is what eopatch managers used to do. Feels crazy that it seems to only be 20 LOC, maybe i'm overlooking something or it shows that the reowork uses a much better abstraction