### PR TITLE
move types to eogrow.types

### DIFF
--- a/eogrow/core/area/base.py
+++ b/eogrow/core/area/base.py
@@ -11,9 +11,9 @@ from pydantic import Field
 
 from sentinelhub import CRS, BBox, Geometry
 
+from ...types import Path
 from ...utils.fs import LocalFile
 from ...utils.grid import GridTransformation
-from ...utils.types import Path
 from ...utils.vector import count_points
 from ..base import EOGrowObject
 from ..schemas import ManagerSchema

--- a/eogrow/core/area/custom_grid.py
+++ b/eogrow/core/area/custom_grid.py
@@ -9,7 +9,7 @@ from pydantic import Field
 
 from sentinelhub import CRS, Geometry
 
-from ...utils.types import Path
+from ...types import Path
 from ...utils.vector import concat_gdf
 from ..schemas import ManagerSchema
 from .base import AreaManager

--- a/eogrow/core/pipeline.py
+++ b/eogrow/core/pipeline.py
@@ -9,9 +9,9 @@ from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar
 from eolearn.core import CreateEOPatchTask, EOExecutor, EONode, EOWorkflow, LoadTask, SaveTask, WorkflowResults
 from eolearn.core.extra.ray import RayExecutor
 
+from ..types import ProcessingType
 from ..utils.meta import import_object
 from ..utils.ray import handle_ray_connection
-from ..utils.types import ProcessingType
 from .area.base import AreaManager
 from .base import EOGrowObject
 from .config import RawConfig

--- a/eogrow/core/schemas.py
+++ b/eogrow/core/schemas.py
@@ -10,7 +10,7 @@ from typing import List, Optional, Type
 from pydantic import BaseModel, Field
 from pydantic.fields import ModelField
 
-from ..utils.types import BoolOrAuto, ImportPath, Path
+from ..types import BoolOrAuto, ImportPath, Path
 from ..utils.validators import field_validator, validate_manager
 from .base import EOGrowObject
 

--- a/eogrow/core/storage.py
+++ b/eogrow/core/storage.py
@@ -8,7 +8,7 @@ from pydantic import BaseSettings, Field
 from eolearn.core.utils.fs import get_aws_credentials, get_filesystem, is_s3_path
 from sentinelhub import SHConfig
 
-from ..utils.types import AwsAclType
+from ..types import AwsAclType
 from .base import EOGrowObject
 from .schemas import ManagerSchema
 

--- a/eogrow/pipelines/batch_to_eopatch.py
+++ b/eogrow/pipelines/batch_to_eopatch.py
@@ -21,8 +21,8 @@ from eolearn.io import ImportFromTiffTask
 from ..core.pipeline import Pipeline
 from ..core.schemas import BaseSchema
 from ..tasks.batch_to_eopatch import DeleteFilesTask, FixImportedTimeDependentFeatureTask, LoadUserDataTask
+from ..types import Feature, FeatureSpec, RawSchemaDict
 from ..utils.filter import get_patches_with_missing_features
-from ..utils.types import Feature, FeatureSpec, RawSchemaDict
 from ..utils.validators import optional_field_validator, parse_dtype
 
 

--- a/eogrow/pipelines/byoc.py
+++ b/eogrow/pipelines/byoc.py
@@ -17,7 +17,7 @@ from sentinelhub.geometry import Geometry
 from eogrow.core.config import RawConfig
 
 from ..core.pipeline import Pipeline
-from ..utils.types import JsonDict
+from ..types import JsonDict
 from ..utils.validators import (
     ensure_defined_together,
     ensure_exactly_one_defined,

--- a/eogrow/pipelines/download.py
+++ b/eogrow/pipelines/download.py
@@ -26,8 +26,8 @@ from sentinelhub.download import SessionSharing, collect_shared_session
 
 from ..core.pipeline import Pipeline
 from ..core.schemas import BaseSchema
+from ..types import Feature, FeatureSpec, Path, ProcessingType, TimePeriod
 from ..utils.filter import get_patches_with_missing_features
-from ..utils.types import Feature, FeatureSpec, Path, ProcessingType, TimePeriod
 from ..utils.validators import (
     ensure_exactly_one_defined,
     field_validator,

--- a/eogrow/pipelines/download_batch.py
+++ b/eogrow/pipelines/download_batch.py
@@ -23,7 +23,7 @@ from sentinelhub import (
 from ..core.area.batch import BatchAreaManager
 from ..core.pipeline import Pipeline
 from ..core.schemas import BaseSchema
-from ..utils.types import Path, TimePeriod
+from ..types import Path, TimePeriod
 from ..utils.validators import field_validator, optional_field_validator, parse_data_collection, parse_time_period
 
 LOGGER = logging.getLogger(__name__)

--- a/eogrow/pipelines/export_maps.py
+++ b/eogrow/pipelines/export_maps.py
@@ -25,8 +25,8 @@ from sentinelhub import CRS, MimeType
 from eogrow.core.config import RawConfig
 
 from ..core.pipeline import Pipeline
+from ..types import Feature
 from ..utils.map import CogifyResamplingOptions, WarpResamplingOptions, cogify_inplace, extract_bands, merge_tiffs
-from ..utils.types import Feature
 
 LOGGER = logging.getLogger(__name__)
 

--- a/eogrow/pipelines/features.py
+++ b/eogrow/pipelines/features.py
@@ -27,8 +27,8 @@ from ..tasks.features import (
     ValidDataFractionPredicate,
     join_valid_and_cloud_masks,
 )
+from ..types import Feature, FeatureSpec, TimePeriod
 from ..utils.filter import get_patches_with_missing_features
-from ..utils.types import Feature, FeatureSpec, TimePeriod
 from ..utils.validators import field_validator, optional_field_validator, parse_dtype, parse_time_period
 
 LOGGER = logging.getLogger(__name__)

--- a/eogrow/pipelines/import_tiff.py
+++ b/eogrow/pipelines/import_tiff.py
@@ -12,8 +12,8 @@ from eolearn.io import ImportFromTiffTask
 
 from ..core.pipeline import Pipeline
 from ..core.schemas import BaseSchema
+from ..types import Feature
 from ..utils.filter import get_patches_with_missing_features
-from ..utils.types import Feature
 from ..utils.validators import optional_field_validator, parse_dtype
 
 

--- a/eogrow/pipelines/mapping.py
+++ b/eogrow/pipelines/mapping.py
@@ -10,7 +10,7 @@ from eolearn.core.exceptions import EODeprecationWarning
 from ..core.config import RawConfig
 from ..core.pipeline import Pipeline
 from ..tasks.common import MappingTask
-from ..utils.types import FeatureSpec
+from ..types import FeatureSpec
 
 
 class MappingPipeline(Pipeline):

--- a/eogrow/pipelines/merge_samples.py
+++ b/eogrow/pipelines/merge_samples.py
@@ -10,7 +10,7 @@ from eolearn.core import EOPatch, EOWorkflow, FeatureType, LoadTask, OutputTask,
 from eolearn.core.utils.fs import get_full_path
 
 from ..core.pipeline import Pipeline
-from ..utils.types import Feature, FeatureSpec
+from ..types import Feature, FeatureSpec
 
 LOGGER = logging.getLogger(__name__)
 

--- a/eogrow/pipelines/prediction.py
+++ b/eogrow/pipelines/prediction.py
@@ -10,8 +10,8 @@ from eolearn.core import EONode, EOWorkflow, FeatureType, LoadTask, MergeEOPatch
 
 from ..core.pipeline import Pipeline
 from ..tasks.prediction import ClassificationPredictionTask, RegressionPredictionTask
+from ..types import Feature, FeatureSpec, RawSchemaDict
 from ..utils.filter import get_patches_with_missing_features
-from ..utils.types import Feature, FeatureSpec, RawSchemaDict
 from ..utils.validators import optional_field_validator, parse_dtype
 
 

--- a/eogrow/pipelines/rasterize.py
+++ b/eogrow/pipelines/rasterize.py
@@ -25,9 +25,9 @@ from eolearn.io import VectorImportTask
 
 from ..core.pipeline import Pipeline
 from ..core.schemas import BaseSchema
+from ..types import Feature, FeatureSpec
 from ..utils.filter import get_patches_with_missing_features
 from ..utils.fs import LocalFile
-from ..utils.types import Feature, FeatureSpec
 from ..utils.validators import ensure_exactly_one_defined, field_validator, parse_dtype
 from ..utils.vector import concat_gdf
 

--- a/eogrow/pipelines/sampling.py
+++ b/eogrow/pipelines/sampling.py
@@ -13,8 +13,8 @@ from eogrow.utils.validators import ensure_exactly_one_defined
 
 from ..core.pipeline import Pipeline
 from ..tasks.common import ClassFilterTask
+from ..types import Feature, FeatureSpec
 from ..utils.filter import get_patches_with_missing_features
-from ..utils.types import Feature, FeatureSpec
 
 
 class BaseSamplingPipeline(Pipeline, metaclass=abc.ABCMeta):

--- a/eogrow/pipelines/split_grid.py
+++ b/eogrow/pipelines/split_grid.py
@@ -16,9 +16,9 @@ from ..core.area.batch import BatchAreaManager
 from ..core.area.utm import UtmZoneAreaManager
 from ..core.pipeline import Pipeline
 from ..tasks.spatial import SpatialSliceTask
+from ..types import Feature, FeatureSpec
 from ..utils.fs import LocalFile
 from ..utils.grid import split_bbox
-from ..utils.types import Feature, FeatureSpec
 
 LOGGER = logging.getLogger(__name__)
 

--- a/eogrow/pipelines/switch_grids.py
+++ b/eogrow/pipelines/switch_grids.py
@@ -12,8 +12,8 @@ from ..core.eopatch import EOPatchManager
 from ..core.pipeline import Pipeline
 from ..core.schemas import BaseSchema, ManagerSchema
 from ..tasks.spatial import SpatialJoinTask, SpatialSliceTask
+from ..types import Feature, FeatureSpec, RawSchemaDict
 from ..utils.grid import GridTransformation
-from ..utils.types import Feature, FeatureSpec, RawSchemaDict
 from ..utils.validators import field_validator, optional_field_validator, validate_manager
 
 LOGGER = logging.getLogger(__name__)

--- a/eogrow/pipelines/testing.py
+++ b/eogrow/pipelines/testing.py
@@ -11,7 +11,7 @@ from ..core.config import RawConfig, recursive_config_join
 from ..core.pipeline import Pipeline
 from ..core.schemas import BaseSchema
 from ..tasks.testing import DummyRasterFeatureTask, DummyTimestampFeatureTask
-from ..utils.types import Feature, TimePeriod
+from ..types import Feature, TimePeriod
 from ..utils.validators import field_validator, parse_dtype, parse_time_period
 
 Self = TypeVar("Self", bound="TestPipeline")

--- a/eogrow/pipelines/zipmap.py
+++ b/eogrow/pipelines/zipmap.py
@@ -17,9 +17,9 @@ from eolearn.core import (
 
 from ..core.pipeline import Pipeline
 from ..core.schemas import BaseSchema
+from ..types import Feature, FeatureSpec
 from ..utils.filter import get_patches_with_missing_features
 from ..utils.meta import import_object
-from ..utils.types import Feature, FeatureSpec
 
 LOGGER = logging.getLogger(__name__)
 

--- a/eogrow/tasks/batch_to_eopatch.py
+++ b/eogrow/tasks/batch_to_eopatch.py
@@ -11,8 +11,8 @@ from eolearn.core import EOPatch, EOTask
 from eolearn.core.utils.fs import pickle_fs, unpickle_fs
 from sentinelhub import parse_time
 
+from ..types import Feature
 from ..utils.meta import import_object
-from ..utils.types import Feature
 
 
 class LoadUserDataTask(EOTask):

--- a/eogrow/tasks/common.py
+++ b/eogrow/tasks/common.py
@@ -6,7 +6,7 @@ import numpy as np
 from eolearn.core import EOPatch, EOTask, MapFeatureTask
 from eolearn.geometry import MorphologicalOperations
 
-from ..utils.types import Feature
+from ..types import Feature
 
 
 class MappingTask(MapFeatureTask):

--- a/eogrow/tasks/features.py
+++ b/eogrow/tasks/features.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from eolearn.core import EOPatch, EOTask, FeatureType, MapFeatureTask
 
-from ..utils.types import Feature
+from ..types import Feature
 
 
 def join_valid_and_cloud_masks(valid_mask: np.ndarray, cloud_mask: np.ndarray) -> np.ndarray:

--- a/eogrow/tasks/prediction.py
+++ b/eogrow/tasks/prediction.py
@@ -10,7 +10,7 @@ from fs.base import FS
 from eolearn.core import EOPatch, EOTask, execute_with_mp_lock
 from eolearn.core.utils.fs import pickle_fs, unpickle_fs
 
-from ..utils.types import Feature
+from ..types import Feature
 
 
 class BasePredictionTask(EOTask, metaclass=abc.ABCMeta):

--- a/eogrow/tasks/spatial.py
+++ b/eogrow/tasks/spatial.py
@@ -7,8 +7,8 @@ from geopandas import GeoDataFrame
 from eolearn.core import EOPatch, EOTask, FeatureType, deep_eq
 from sentinelhub import CRS, BBox, bbox_to_resolution
 
+from ..types import Feature, FeatureSpec
 from ..utils.general import convert_to_int
-from ..utils.types import Feature, FeatureSpec
 from ..utils.vector import concat_gdf
 
 

--- a/eogrow/tasks/testing.py
+++ b/eogrow/tasks/testing.py
@@ -7,7 +7,7 @@ import numpy as np
 from eolearn.core import EOPatch, EOTask, FeatureTypeSet
 from eolearn.core.utils.common import is_discrete_type
 
-from ..utils.types import Feature, TimePeriod
+from ..types import Feature, TimePeriod
 
 
 class DummyRasterFeatureTask(EOTask):

--- a/eogrow/types.py
+++ b/eogrow/types.py
@@ -1,0 +1,36 @@
+""" Includes custom types used in schemas
+"""
+import datetime
+from enum import Enum
+from typing import Any, Dict, Literal, Tuple, Union
+
+from eolearn.core import FeatureType
+
+Path = str
+ImportPath = str
+TimePeriod = Tuple[datetime.date, datetime.date]
+
+Feature = Tuple[FeatureType, str]
+FeatureSpec = Union[Tuple[FeatureType, str], FeatureType]
+
+BoolOrAuto = Union[Literal["auto"], bool]
+
+JsonDict = Dict[str, Any]
+RawSchemaDict = Dict[str, Any]
+
+AwsAclType = Literal[
+    "private",
+    "public-read",
+    "public-read-write",
+    "aws-exec-read",
+    "authenticated-read",
+    "bucket-owner-read",
+    "bucket-owner-full-control",
+    "log-delivery-write",
+]
+
+
+class ProcessingType(Enum):
+    RAY = "ray"
+    SINGLE = "single"
+    MULTI = "multi"

--- a/eogrow/utils/filter.py
+++ b/eogrow/utils/filter.py
@@ -10,9 +10,9 @@ from tqdm.auto import tqdm
 
 from eolearn.core import FeatureType
 from eolearn.core.eodata_io import walk_filesystem
-from eolearn.core.utils.types import EllipsisType
+from eolearn.core.types import EllipsisType
 
-from ..utils.types import FeatureSpec
+from ..types import FeatureSpec
 
 
 def check_if_features_exist(

--- a/eogrow/utils/filter.py
+++ b/eogrow/utils/filter.py
@@ -10,7 +10,7 @@ from tqdm.auto import tqdm
 
 from eolearn.core import FeatureType
 from eolearn.core.eodata_io import walk_filesystem
-from eolearn.core.types import EllipsisType
+from eolearn.core.utils.types import EllipsisType
 
 from ..types import FeatureSpec
 

--- a/eogrow/utils/testing.py
+++ b/eogrow/utils/testing.py
@@ -19,8 +19,8 @@ from sentinelhub import BBox
 
 from ..core.config import collect_configs_from_path, interpret_config_from_dict
 from ..core.pipeline import Pipeline
+from ..types import JsonDict
 from ..utils.meta import load_pipeline_class
-from ..utils.types import JsonDict
 
 
 class ContentTester:

--- a/eogrow/utils/types.py
+++ b/eogrow/utils/types.py
@@ -1,37 +1,10 @@
-""" Includes custom types used in schemas
-"""
-import datetime
-from enum import Enum
-from typing import Any, Dict, Literal, Tuple, Union
+"""Deprecated module for types, moved to `eogrow.types`."""
+from warnings import warn
 
-from eolearn.core import FeatureType
+from ..types import *  # noqa # pylint: disable=wildcard-import,unused-wildcard-import
 
-Path = str
-S3Path = str
-ImportPath = str
-TimePeriod = Tuple[datetime.date, datetime.date]
-
-Feature = Tuple[FeatureType, str]
-FeatureSpec = Union[Tuple[FeatureType, str], FeatureType]
-
-BoolOrAuto = Union[Literal["auto"], bool]
-
-JsonDict = Dict[str, Any]
-RawSchemaDict = Dict[str, Any]
-
-AwsAclType = Literal[
-    "private",
-    "public-read",
-    "public-read-write",
-    "aws-exec-read",
-    "authenticated-read",
-    "bucket-owner-read",
-    "bucket-owner-full-control",
-    "log-delivery-write",
-]
-
-
-class ProcessingType(Enum):
-    RAY = "ray"
-    SINGLE = "single"
-    MULTI = "multi"
+warn(
+    "The module `eogrow.types` is deprecated, use `eogrow.types` instead.",
+    category=DeprecationWarning,
+    stacklevel=2,
+)

--- a/eogrow/utils/types.py
+++ b/eogrow/utils/types.py
@@ -4,7 +4,7 @@ from warnings import warn
 from ..types import *  # noqa # pylint: disable=wildcard-import,unused-wildcard-import
 
 warn(
-    "The module `eogrow.types` is deprecated, use `eogrow.types` instead.",
+    "The module `eogrow.utils.types` is deprecated, use `eogrow.types` instead.",
     category=DeprecationWarning,
     stacklevel=2,
 )

--- a/eogrow/utils/validators.py
+++ b/eogrow/utils/validators.py
@@ -12,7 +12,7 @@ from sentinelhub import DataCollection
 from sentinelhub.data_collections_bands import Band, Bands, MetaBands, Unit
 
 from .meta import collect_schema, import_object
-from .types import RawSchemaDict, S3Path, TimePeriod
+from .types import RawSchemaDict, TimePeriod
 
 if TYPE_CHECKING:
     from ..core.schemas import ManagerSchema
@@ -49,7 +49,7 @@ def optional_field_validator(
     return validator(field, allow_reuse=allow_reuse, **kwargs)(optional_validator)
 
 
-def validate_s3_path(value: S3Path) -> S3Path:
+def validate_s3_path(value: str) -> str:
     """Validates the prefix of a S3 bucket path"""
     assert value.startswith("s3://"), "S3 path must start with s3://"
     return value

--- a/tests/test_utils/test_validators.py
+++ b/tests/test_utils/test_validators.py
@@ -10,7 +10,7 @@ from sentinelhub import DataCollection
 from sentinelhub.data_collections_bands import Band, MetaBands, Unit
 
 from eogrow.core.schemas import BaseSchema, ManagerSchema
-from eogrow.utils.types import RawSchemaDict
+from eogrow.types import RawSchemaDict
 from eogrow.utils.validators import (
     ensure_defined_together,
     ensure_exactly_one_defined,


### PR DESCRIPTION
Move type module. Decided to remove `S3Path` type alias, the rest can stay for now.