### PR TITLE
Correct batch grid caching in download pipeline

### DIFF
--- a/eogrow/core/area/batch.py
+++ b/eogrow/core/area/batch.py
@@ -95,7 +95,14 @@ class BatchAreaManager(BaseAreaManager):
         """Verifies that the given batch request has finished and that it contains the same tiling grid parameters as
         in the config.
         """
-        batch_request.raise_for_status(status=[BatchRequestStatus.FAILED, BatchRequestStatus.CANCELED])
+        batch_request.raise_for_status(
+            status=(
+                BatchRequestStatus.CREATED,  # tiles not available prior to analysis
+                BatchRequestStatus.ANALYSING,  # tiles not available prior to analysis
+                BatchRequestStatus.FAILED,
+                BatchRequestStatus.CANCELED,
+            )
+        )
 
         expected_tiling_grid_params = {
             "id": self.config.tiling_grid_id,

--- a/eogrow/pipelines/download_batch.py
+++ b/eogrow/pipelines/download_batch.py
@@ -127,7 +127,6 @@ class BatchDownloadPipeline(Pipeline):
     def run_procedure(self) -> Tuple[List[str], List[str]]:
         """Procedure that uses Sentinel Hub batch service to download data to an S3 bucket."""
         batch_request = self._create_or_collect_batch_request()
-        self.cache_batch_area_manager_grid(batch_request.request_id)
 
         user_action = self._trigger_user_action(batch_request)
 
@@ -140,6 +139,8 @@ class BatchDownloadPipeline(Pipeline):
                 config=self.sh_config,
                 sleep_time=self.config.monitoring_analysis_sleep_time,
             )
+
+        self.cache_batch_area_manager_grid(batch_request.request_id)
 
         if self.config.analysis_only:
             return [], []


### PR DESCRIPTION
Tiles are only available AFTER analysis is done.

I moved the forced caching to a later point and added pre-analysis statuses to cause an error, so that such issues are detected.