### PR TITLE
Fix tests to avoid get_features method

### DIFF
--- a/eogrow/utils/eopatch_list.py
+++ b/eogrow/utils/eopatch_list.py
@@ -8,7 +8,7 @@ from fs.base import FS
 
 from sentinelhub import CRS
 
-from .types import PatchList
+from ..types import PatchList
 
 
 def save_eopatch_names(filesystem: FS, file_path: str, eopatch_list: List[str]) -> None:

--- a/eogrow/utils/ray.py
+++ b/eogrow/utils/ray.py
@@ -5,7 +5,7 @@ import logging
 
 import ray
 
-from .types import BoolOrAuto
+from ..types import BoolOrAuto
 
 LOGGER = logging.getLogger(__name__)
 

--- a/eogrow/utils/testing.py
+++ b/eogrow/utils/testing.py
@@ -4,7 +4,7 @@ Module implementing utilities for unit testing pipeline results
 import functools
 import json
 import os
-from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, cast
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, cast
 
 import fs
 import numpy as np
@@ -129,7 +129,10 @@ class ContentTester:
         """Calculates statistics of given EOPatch and it's content"""
         stats: Dict[str, object] = {}
 
-        for feature_type, feature_set in eopatch.get_features().items():
+        for feature_type in FeatureType:
+            if feature_type not in eopatch:
+                continue
+
             feature_type_name = feature_type.value
 
             if feature_type is FeatureType.BBOX:
@@ -139,7 +142,6 @@ class ContentTester:
                 stats[feature_type_name] = [time.isoformat() for time in eopatch.timestamp]
 
             else:
-                feature_set = cast(Set[str], feature_set)
                 feature_stats_dict = {}
 
                 if feature_type.is_raster():
@@ -149,7 +151,7 @@ class ContentTester:
                 else:  # Only FeatureType.META_INFO remains
                     calculation_method = str
 
-                for feature_name in feature_set:
+                for feature_name in eopatch[feature_type]:
                     feature_stats_dict[feature_name] = calculation_method(eopatch[feature_type][feature_name])
 
                 stats[feature_type_name] = feature_stats_dict

--- a/eogrow/utils/validators.py
+++ b/eogrow/utils/validators.py
@@ -11,8 +11,8 @@ from pydantic import BaseModel, Field, root_validator, validator
 from sentinelhub import DataCollection
 from sentinelhub.data_collections_bands import Band, Bands, MetaBands, Unit
 
+from ..types import RawSchemaDict, TimePeriod
 from .meta import collect_schema, import_object
-from .types import RawSchemaDict, TimePeriod
 
 if TYPE_CHECKING:
     from ..core.schemas import ManagerSchema

--- a/tests/test_tasks/test_testing.py
+++ b/tests/test_tasks/test_testing.py
@@ -26,7 +26,10 @@ def test_dummy_raster_feature_task(feature_type, shape, dtype, min_value, max_va
     eopatch = task.execute()
 
     assert isinstance(eopatch, EOPatch)
-    assert eopatch.get_feature_list() == [feature]
+
+    assert feature in eopatch
+    assert len(eopatch.get_features()) == 1
+
     data = eopatch[feature]
     assert data.shape == shape
     assert data.dtype == dtype
@@ -47,7 +50,10 @@ def test_dummy_timestamp_feature_task():
     eopatch = task.execute()
 
     assert isinstance(eopatch, EOPatch)
-    assert eopatch.get_feature_list() == [FeatureType.TIMESTAMP]
+
+    assert FeatureType.TIMESTAMP in eopatch
+    assert len(eopatch.get_features()) == 1
+
     assert len(eopatch.timestamp) == timestamp_num
     assert eopatch.timestamp == sorted(eopatch.timestamp)
     assert eopatch.timestamp[0] >= start_time


### PR DESCRIPTION
1. fixed testing util to not need any method
2. fixed tests for testing tasks so that they dont care if eolearn is 1.3.1 or 1.4
3. fixed some deprecation errors by correcting paths