### PR TITLE
Updates needed for storing eo-patches on non AWS s3 buckets.

### DIFF
--- a/eogrow/pipelines/byoc.py
+++ b/eogrow/pipelines/byoc.py
@@ -72,7 +72,7 @@ class IngestByocTilesPipeline(Pipeline):
 
     def __init__(self, config: Schema, raw_config: Optional[RawConfig] = None):
         super().__init__(config, raw_config)
-        if not self.storage.is_on_aws():
+        if not self.storage.is_on_s3():
             raise ValueError("Can only ingest for projects based on S3 storage.")
         project_folder = self.storage.config.project_folder
         self.bucket_name = project_folder.replace("s3://", "").split("/")[0]

--- a/eogrow/pipelines/download_batch.py
+++ b/eogrow/pipelines/download_batch.py
@@ -201,7 +201,7 @@ class BatchDownloadPipeline(Pipeline):
         )
 
         data_folder = self.storage.get_folder(self.config.output_folder_key, full_path=True).rstrip("/")
-        if not self.storage.is_on_aws():
+        if not self.storage.is_on_s3():
             raise ValueError(f"The data folder path should be on s3 bucket, got {data_folder}")
 
         return self.batch_client.create(

--- a/eogrow/pipelines/export_maps.py
+++ b/eogrow/pipelines/export_maps.py
@@ -205,7 +205,7 @@ class ExportMapsPipeline(Pipeline):
 
         If required files are copied locally and a temporary filesystem object is returned.
         """
-        make_local_copies = self.storage.is_on_aws() or self.config.force_local_copies
+        make_local_copies = self.storage.is_on_s3() or self.config.force_local_copies
 
         if not make_local_copies:
             return self.storage.filesystem, geotiff_paths

--- a/eogrow/types.py
+++ b/eogrow/types.py
@@ -27,17 +27,6 @@ BoolOrAuto: TypeAlias = Union[Literal["auto"], bool]
 JsonDict: TypeAlias = Dict[str, Any]
 RawSchemaDict: TypeAlias = Dict[str, Any]
 
-AwsAclType: TypeAlias = Literal[
-    "private",
-    "public-read",
-    "public-read-write",
-    "aws-exec-read",
-    "authenticated-read",
-    "bucket-owner-read",
-    "bucket-owner-full-control",
-    "log-delivery-write",
-]
-
 
 class ProcessingType(Enum):
     RAY = "ray"

--- a/tests/test_core/test_storage.py
+++ b/tests/test_core/test_storage.py
@@ -114,6 +114,6 @@ def test_aws_acl(config: RawConfig):
     storage = StorageManager.from_raw_config(config)
 
     if isinstance(storage.filesystem, S3FS):
-        config_acl = config.get("filesystem_kwargs").get("acl") if config.get("filesystem_kwargs") else None
+        config_acl = config.get("filesystem_kwargs").get("acl") if "filesystem_kwargs" in config else None
         filesystem_acl = None if storage.filesystem.upload_args is None else storage.filesystem.upload_args.get("ACL")
         assert config_acl == filesystem_acl

--- a/tests/test_core/test_storage.py
+++ b/tests/test_core/test_storage.py
@@ -105,15 +105,15 @@ def test_aws_profile(aws_storage_config: RawConfig, config_profile: Optional[str
 @pytest.mark.parametrize(
     "config",
     [
-        {"project_folder": "s3://fake-bucket/", "aws_acl": "bucket-owner-full-control"},
+        {"project_folder": "s3://fake-bucket/", "filesystem_kwargs": {"acl": "bucket-owner-full-control"}},
         {"project_folder": "s3://fake-bucket/"},
-        {"project_folder": ".", "aws_acl": "public-read"},
+        {"project_folder": "."},
     ],
 )
 def test_aws_acl(config: RawConfig):
     storage = StorageManager.from_raw_config(config)
 
     if isinstance(storage.filesystem, S3FS):
-        config_acl = config.get("aws_acl")
+        config_acl = config.get("filesystem_kwargs").get("acl") if config.get("filesystem_kwargs") else None
         filesystem_acl = None if storage.filesystem.upload_args is None else storage.filesystem.upload_args.get("ACL")
         assert config_acl == filesystem_acl

--- a/tests/test_pipelines/test_byoc.py
+++ b/tests/test_pipelines/test_byoc.py
@@ -64,7 +64,7 @@ def run_byoc_pipeline(config_folder: str, config: str, preparation_config: str, 
         return Geometry(Polygon(MOCK_COVER_GEOM), crs=CRS.WGS84)
 
     # patch storage manager so it believes it's on aws, but only during init
-    with patch.object(StorageManager, "is_on_aws", lambda _: True):
+    with patch.object(StorageManager, "is_on_s3", lambda _: True):
         SentinelHubDownloadClient._CACHED_SESSIONS = {}
         pipeline = IngestByocTilesPipeline.from_path(config_path)
         pipeline.bucket_name = "mock-bucket"


### PR DESCRIPTION
This PR addresses the following:

 * removes AWS specific ACLs
 * adds option to add "any FS kwargs" to storage manager
 * renames the method `is_on_aws` to `is_on_s3`, which is more appropriate
 * removes passing acl option to local fs; now adding non-appropriate kwargs to fs will fail (as it should)

With this changes, accessing eo-patches on non AWS S3 buckets is possible (e.g. creodias).