### PR TITLE
Remove aoi modification in area managers

### DIFF
--- a/eogrow/core/area/base.py
+++ b/eogrow/core/area/base.py
@@ -36,7 +36,15 @@ class AreaSchema(BaseSchema):
 def area_schema_deprecation(cls: type, value: Optional[str], values: RawSchemaDict) -> str:
     """Warns and reconfigures when `area` is used instead of `geometry_filename`."""
     if values.get("area") is not None:
-        warnings.warn("Use `geometry_filename` instead of `area`.", EODeprecationWarning, stacklevel=2)
+        warnings.warn(
+            (
+                "Use `geometry_filename` to provide the file (e.g., geojson, gpkg) with AoI. The `area` parameter is"
+                " deprecated, and extra parameters like `buffer` and `simplification_factor` are no longer available;"
+                " should prepare the AoI geometry by themselves."
+            ),
+            EODeprecationWarning,
+            stacklevel=2,
+        )
         return values["area"].filename
     assert value is not None, "Specify the `geometry_filename` parameter."
     return value

--- a/eogrow/core/area/base.py
+++ b/eogrow/core/area/base.py
@@ -1,5 +1,6 @@
 """Implementation of the base AreaManager."""
 import logging
+import warnings
 from abc import ABCMeta, abstractmethod
 from typing import Dict, Literal, Optional
 
@@ -9,9 +10,10 @@ import geopandas as gpd
 import shapely.ops
 from pydantic import Field
 
+from eolearn.core.exceptions import EODeprecationWarning
 from sentinelhub import CRS, BBox, Geometry
 
-from ...types import PatchList
+from ...types import PatchList, RawSchemaDict
 from ...utils.eopatch_list import load_names
 from ...utils.fs import LocalFile
 from ..base import EOGrowObject
@@ -29,6 +31,15 @@ class AreaSchema(BaseSchema):
     simplification_factor: Optional[float] = Field(
         description="Tolerance factor (in CRS units) for simplifying the buffered area geometry before splitting it.",
     )
+
+
+def area_schema_deprecation(cls: type, value: Optional[str], values: RawSchemaDict) -> str:
+    """Warns and reconfigures when `area` is used instead of `aoi_filename`."""
+    if values.get("area") is not None:
+        warnings.warn("Use `aoi_filename` instead of `area`.", EODeprecationWarning, stacklevel=2)
+        return values["area"].filename
+    assert value is not None, "Specify the `aoi_filename` parameter."
+    return value
 
 
 class PatchListSchema(BaseSchema):
@@ -148,22 +159,10 @@ class BaseAreaManager(EOGrowObject, metaclass=ABCMeta):
 
 
 def get_geometry_from_file(
-    filesystem: fs.base.FS,
-    file_path: str,
-    buffer: Optional[float],
-    simplification_factor: Optional[float],
-    geopandas_engine: Literal["fiona", "pyogrio"] = "fiona",
+    filesystem: fs.base.FS, file_path: str, geopandas_engine: Literal["fiona", "pyogrio"] = "fiona"
 ) -> Geometry:
     """Provides a single geometry object of entire AOI"""
     with LocalFile(file_path, mode="r", filesystem=filesystem) as local_file:
         area_df = gpd.read_file(local_file.path, engine=geopandas_engine)
-
-    area_shape = shapely.ops.unary_union(area_df.geometry)
-
-    if buffer is not None:
-        area_shape = area_shape.buffer(buffer)
-
-    if simplification_factor is not None:
-        area_shape = area_shape.simplify(simplification_factor, preserve_topology=True)
-
-    return Geometry(area_shape, CRS(area_df.crs))
+        area_shape = shapely.ops.unary_union(area_df.geometry)
+        return Geometry(area_shape, CRS(area_df.crs))

--- a/eogrow/core/area/base.py
+++ b/eogrow/core/area/base.py
@@ -40,7 +40,7 @@ def area_schema_deprecation(cls: type, value: Optional[str], values: RawSchemaDi
             (
                 "Use `geometry_filename` to provide the file (e.g., geojson, gpkg) with AoI. The `area` parameter is"
                 " deprecated, and extra parameters like `buffer` and `simplification_factor` are no longer available;"
-                " should prepare the AoI geometry by themselves."
+                " users should prepare the AoI geometry by themselves."
             ),
             EODeprecationWarning,
             stacklevel=2,

--- a/eogrow/core/area/base.py
+++ b/eogrow/core/area/base.py
@@ -34,11 +34,11 @@ class AreaSchema(BaseSchema):
 
 
 def area_schema_deprecation(cls: type, value: Optional[str], values: RawSchemaDict) -> str:
-    """Warns and reconfigures when `area` is used instead of `aoi_filename`."""
+    """Warns and reconfigures when `area` is used instead of `geometry_filename`."""
     if values.get("area") is not None:
-        warnings.warn("Use `aoi_filename` instead of `area`.", EODeprecationWarning, stacklevel=2)
+        warnings.warn("Use `geometry_filename` instead of `area`.", EODeprecationWarning, stacklevel=2)
         return values["area"].filename
-    assert value is not None, "Specify the `aoi_filename` parameter."
+    assert value is not None, "Specify the `geometry_filename` parameter."
     return value
 
 

--- a/eogrow/core/area/batch.py
+++ b/eogrow/core/area/batch.py
@@ -25,7 +25,7 @@ class BatchAreaManager(BaseAreaManager):
     """Area manager that splits grid per UTM zones"""
 
     class Schema(BaseAreaManager.Schema):
-        area: Optional[AreaSchema]
+        area: Optional[AreaSchema] = Field(description="DEPRECATED, use `aoi_filename` instead.")
         aoi_filename: str = None  # type: ignore[assignment]
         tiling_grid_id: int = Field(
             description="An id of one of the tiling grids predefined at Sentinel Hub Batch service."

--- a/eogrow/core/area/batch.py
+++ b/eogrow/core/area/batch.py
@@ -25,8 +25,8 @@ class BatchAreaManager(BaseAreaManager):
     """Area manager that splits grid per UTM zones"""
 
     class Schema(BaseAreaManager.Schema):
-        area: Optional[AreaSchema] = Field(description="DEPRECATED, use `aoi_filename` instead.")
-        aoi_filename: str = None  # type: ignore[assignment]
+        area: Optional[AreaSchema] = Field(description="DEPRECATED, use `geometry_filename` instead.")
+        geometry_filename: str = None  # type: ignore[assignment]
         tiling_grid_id: int = Field(
             description="An id of one of the tiling grids predefined at Sentinel Hub Batch service."
         )
@@ -45,7 +45,7 @@ class BatchAreaManager(BaseAreaManager):
             ),
         )
 
-        _warn_and_adapt_old_config = field_validator("aoi_filename", area_schema_deprecation, pre=True)
+        _warn_and_adapt_old_config = field_validator("geometry_filename", area_schema_deprecation, pre=True)
 
     config: Schema
 
@@ -56,7 +56,7 @@ class BatchAreaManager(BaseAreaManager):
         self._injected_batch_id: Optional[str] = None
 
     def get_area_geometry(self, *, crs: CRS = CRS.WGS84) -> Geometry:
-        file_path = fs.path.join(self.storage.get_input_data_folder(), self.config.aoi_filename)
+        file_path = fs.path.join(self.storage.get_input_data_folder(), self.config.geometry_filename)
         return get_geometry_from_file(
             filesystem=self.storage.filesystem,
             file_path=file_path,
@@ -119,7 +119,7 @@ class BatchAreaManager(BaseAreaManager):
             )
 
     def get_grid_cache_filename(self) -> str:
-        input_filename = fs.path.basename(self.config.aoi_filename)
+        input_filename = fs.path.basename(self.config.geometry_filename)
         input_filename = input_filename.rsplit(".", 1)[0]
 
         raw_params = [

--- a/eogrow/core/area/batch.py
+++ b/eogrow/core/area/batch.py
@@ -26,7 +26,9 @@ class BatchAreaManager(BaseAreaManager):
 
     class Schema(BaseAreaManager.Schema):
         area: Optional[AreaSchema] = Field(description="DEPRECATED, use `geometry_filename` instead.")
-        geometry_filename: str = None  # type: ignore[assignment]
+        geometry_filename: str = Field(  # type:ignore[assignment]
+            None, description="Name of the file that defines the AoI geometry, located in the input data folder."
+        )
         tiling_grid_id: int = Field(
             description="An id of one of the tiling grids predefined at Sentinel Hub Batch service."
         )

--- a/eogrow/core/area/utm.py
+++ b/eogrow/core/area/utm.py
@@ -30,7 +30,9 @@ class UtmZoneAreaManager(BaseAreaManager):
 
     class Schema(BaseAreaManager.Schema):
         area: Optional[AreaSchema] = Field(description="DEPRECATED, use `geometry_filename` instead.")
-        geometry_filename: str = None  # type: ignore[assignment]
+        geometry_filename: str = Field(  # type:ignore[assignment]
+            None, description="Name of the file that defines the AoI geometry, located in the input data folder."
+        )
         patch: PatchSchema
 
         offset_x: float = Field(0, description="An offset of tiling grid in horizontal dimension")

--- a/eogrow/core/area/utm.py
+++ b/eogrow/core/area/utm.py
@@ -2,7 +2,7 @@
 
 import logging
 from collections import defaultdict
-from typing import Dict
+from typing import Dict, Optional
 
 import fs
 import geopandas as gpd
@@ -11,8 +11,9 @@ from pydantic import Field
 
 from sentinelhub import CRS, Geometry, UtmZoneSplitter
 
+from ...utils.validators import field_validator
 from ..schemas import BaseSchema
-from .base import AreaSchema, BaseAreaManager, get_geometry_from_file
+from .base import AreaSchema, BaseAreaManager, area_schema_deprecation, get_geometry_from_file
 
 LOGGER = logging.getLogger(__name__)
 
@@ -28,21 +29,22 @@ class UtmZoneAreaManager(BaseAreaManager):
     """Area manager that splits grid per UTM zones"""
 
     class Schema(BaseAreaManager.Schema):
-        area: AreaSchema
+        area: Optional[AreaSchema]
+        aoi_filename: str = None  # type: ignore[assignment]
         patch: PatchSchema
 
         offset_x: float = Field(0, description="An offset of tiling grid in horizontal dimension")
         offset_y: float = Field(0, description="An offset of tiling grid in vertical dimension")
 
+        _warn_and_adapt_old_config = field_validator("aoi_filename", area_schema_deprecation, pre=True)
+
     config: Schema
 
     def get_area_geometry(self, *, crs: CRS = CRS.WGS84) -> Geometry:
-        file_path = fs.path.join(self.storage.get_input_data_folder(), self.config.area.filename)
+        file_path = fs.path.join(self.storage.get_input_data_folder(), self.config.aoi_filename)
         return get_geometry_from_file(
             filesystem=self.storage.filesystem,
             file_path=file_path,
-            buffer=self.config.area.buffer,
-            simplification_factor=self.config.area.simplification_factor,
             geopandas_engine=self.storage.config.geopandas_backend,
         ).transform(crs)
 
@@ -78,7 +80,7 @@ class UtmZoneAreaManager(BaseAreaManager):
         return grid
 
     def get_grid_cache_filename(self) -> str:
-        input_filename = fs.path.basename(self.config.area.filename)
+        input_filename = fs.path.basename(self.config.aoi_filename)
         input_filename = input_filename.rsplit(".", 1)[0]
 
         raw_params = [

--- a/eogrow/core/area/utm.py
+++ b/eogrow/core/area/utm.py
@@ -29,19 +29,19 @@ class UtmZoneAreaManager(BaseAreaManager):
     """Area manager that splits grid per UTM zones"""
 
     class Schema(BaseAreaManager.Schema):
-        area: Optional[AreaSchema] = Field(description="DEPRECATED, use `aoi_filename` instead.")
-        aoi_filename: str = None  # type: ignore[assignment]
+        area: Optional[AreaSchema] = Field(description="DEPRECATED, use `geometry_filename` instead.")
+        geometry_filename: str = None  # type: ignore[assignment]
         patch: PatchSchema
 
         offset_x: float = Field(0, description="An offset of tiling grid in horizontal dimension")
         offset_y: float = Field(0, description="An offset of tiling grid in vertical dimension")
 
-        _warn_and_adapt_old_config = field_validator("aoi_filename", area_schema_deprecation, pre=True)
+        _warn_and_adapt_old_config = field_validator("geometry_filename", area_schema_deprecation, pre=True)
 
     config: Schema
 
     def get_area_geometry(self, *, crs: CRS = CRS.WGS84) -> Geometry:
-        file_path = fs.path.join(self.storage.get_input_data_folder(), self.config.aoi_filename)
+        file_path = fs.path.join(self.storage.get_input_data_folder(), self.config.geometry_filename)
         return get_geometry_from_file(
             filesystem=self.storage.filesystem,
             file_path=file_path,
@@ -80,7 +80,7 @@ class UtmZoneAreaManager(BaseAreaManager):
         return grid
 
     def get_grid_cache_filename(self) -> str:
-        input_filename = fs.path.basename(self.config.aoi_filename)
+        input_filename = fs.path.basename(self.config.geometry_filename)
         input_filename = input_filename.rsplit(".", 1)[0]
 
         raw_params = [

--- a/eogrow/core/area/utm.py
+++ b/eogrow/core/area/utm.py
@@ -29,7 +29,7 @@ class UtmZoneAreaManager(BaseAreaManager):
     """Area manager that splits grid per UTM zones"""
 
     class Schema(BaseAreaManager.Schema):
-        area: Optional[AreaSchema]
+        area: Optional[AreaSchema] = Field(description="DEPRECATED, use `aoi_filename` instead.")
         aoi_filename: str = None  # type: ignore[assignment]
         patch: PatchSchema
 

--- a/tests/test_config_files/global_config.json
+++ b/tests/test_config_files/global_config.json
@@ -1,7 +1,7 @@
 {
   "area": {
     "manager": "eogrow.core.area.UtmZoneAreaManager",
-    "aoi_filename": "test_area.geojson",
+    "geometry_filename": "test_area.geojson",
     "patch":{
       "size_x": 2400,
       "size_y": 1100,

--- a/tests/test_config_files/global_config.json
+++ b/tests/test_config_files/global_config.json
@@ -1,10 +1,7 @@
 {
   "area": {
     "manager": "eogrow.core.area.UtmZoneAreaManager",
-    "area": {
-      "filename": "test_area.geojson",
-      "buffer": 0.001
-    },
+    "aoi_filename": "test_area.geojson",
     "patch":{
       "size_x": 2400,
       "size_y": 1100,

--- a/tests/test_config_files/split_grid/dummy_data_batch.json
+++ b/tests/test_config_files/split_grid/dummy_data_batch.json
@@ -4,9 +4,7 @@
   "**global_config": "${config_path}/global_config.json",
   "area": { // These parameters must match the content of test_project/input-data/batch_grid.gpkg grid file
     "manager": "eogrow.core.area.BatchAreaManager",
-    "area": {
-      "filename": "batch_area.geojson"
-    },
+    "aoi_filename": "batch_area.geojson",
     "tiling_grid_id": 1,
     "resolution": 10,
     "tile_buffer_x": 3,

--- a/tests/test_config_files/split_grid/dummy_data_batch.json
+++ b/tests/test_config_files/split_grid/dummy_data_batch.json
@@ -4,7 +4,7 @@
   "**global_config": "${config_path}/global_config.json",
   "area": { // These parameters must match the content of test_project/input-data/batch_grid.gpkg grid file
     "manager": "eogrow.core.area.BatchAreaManager",
-    "aoi_filename": "batch_area.geojson",
+    "geometry_filename": "batch_area.geojson",
     "tiling_grid_id": 1,
     "resolution": 10,
     "tile_buffer_x": 3,

--- a/tests/test_config_files/split_grid/dummy_data_utm.json
+++ b/tests/test_config_files/split_grid/dummy_data_utm.json
@@ -4,7 +4,7 @@
   "**global_config": "${config_path}/global_config.json",
   "area": {
     "manager": "eogrow.core.area.UtmZoneAreaManager",
-    "aoi_filename": "test_area.geojson",
+    "geometry_filename": "test_area.geojson",
     "patch":{
       "size_x": 3600,
       "size_y": 3000,

--- a/tests/test_config_files/split_grid/dummy_data_utm.json
+++ b/tests/test_config_files/split_grid/dummy_data_utm.json
@@ -4,10 +4,7 @@
   "**global_config": "${config_path}/global_config.json",
   "area": {
     "manager": "eogrow.core.area.UtmZoneAreaManager",
-    "area":{
-      "filename": "test_area.geojson",
-      "buffer": 0.01
-    },
+    "aoi_filename": "test_area.geojson",
     "patch":{
       "size_x": 3600,
       "size_y": 3000,

--- a/tests/test_config_files/split_grid/split_batch.json
+++ b/tests/test_config_files/split_grid/split_batch.json
@@ -6,9 +6,7 @@
     "**common_config": "${config_path}/global_config.json",
     "area": { // These parameters must match the content of test_project/input-data/batch_grid.gpkg grid file
       "manager": "eogrow.core.area.BatchAreaManager",
-      "area": {
-        "filename": "batch_area.geojson"
-      },
+      "aoi_filename": "batch_area.geojson",
       "tiling_grid_id": 1,
       "resolution": 10,
       "tile_buffer_x": 3,

--- a/tests/test_config_files/split_grid/split_batch.json
+++ b/tests/test_config_files/split_grid/split_batch.json
@@ -6,7 +6,7 @@
     "**common_config": "${config_path}/global_config.json",
     "area": { // These parameters must match the content of test_project/input-data/batch_grid.gpkg grid file
       "manager": "eogrow.core.area.BatchAreaManager",
-      "aoi_filename": "batch_area.geojson",
+      "geometry_filename": "batch_area.geojson",
       "tiling_grid_id": 1,
       "resolution": 10,
       "tile_buffer_x": 3,

--- a/tests/test_config_files/split_grid/split_utm.json
+++ b/tests/test_config_files/split_grid/split_utm.json
@@ -6,10 +6,7 @@
     "**common_config": "${config_path}/global_config.json",
     "area": {
       "manager": "eogrow.core.area.UtmZoneAreaManager",
-      "area":{
-        "filename": "test_area.geojson",
-        "buffer": 0.01
-      },
+      "aoi_filename": "test_area.geojson",
       "patch":{
         "size_x": 3600,
         "size_y": 3000,

--- a/tests/test_config_files/split_grid/split_utm.json
+++ b/tests/test_config_files/split_grid/split_utm.json
@@ -6,7 +6,7 @@
     "**common_config": "${config_path}/global_config.json",
     "area": {
       "manager": "eogrow.core.area.UtmZoneAreaManager",
-      "aoi_filename": "test_area.geojson",
+      "geometry_filename": "test_area.geojson",
       "patch":{
         "size_x": 3600,
         "size_y": 3000,

--- a/tests/test_core/test_area/test_base.py
+++ b/tests/test_core/test_area/test_base.py
@@ -98,20 +98,12 @@ def test_get_patch_list(patch_list: List[str], expected_bboxes: List[Tuple[str, 
     assert expected_bboxes == manager.get_patch_list(), "Filtration fails on reading from cache."
 
 
-@pytest.mark.parametrize(
-    "simplification_factor,expected_point_count", [(0, 128), (0.00001, 64), (0.0001, 25), (0.001, 10), (0.1, 5)]
-)
 @pytest.mark.parametrize("engine", ["fiona", "pyogrio"])
-def test_get_geometry_from_file(
-    storage: StorageManager,
-    simplification_factor: float,
-    expected_point_count: int,
-    engine: Literal["fiona", "pyogrio"],
-):
+def test_get_geometry_from_file(storage: StorageManager, engine: Literal["fiona", "pyogrio"]):
     file_path = fs.path.join(storage.get_input_data_folder(), "test_area.geojson")
 
-    geometry = get_geometry_from_file(storage.filesystem, file_path, 0.001, simplification_factor, engine)
-    assert count_points(geometry.geometry) == expected_point_count
+    geometry = get_geometry_from_file(storage.filesystem, file_path, engine)
+    assert count_points(geometry.geometry) == 20
 
 
 def _prepare_patch_list_config(storage: StorageManager, patch_list: List[str]) -> RawConfig:

--- a/tests/test_core/test_area/test_batch.py
+++ b/tests/test_core/test_area/test_batch.py
@@ -54,11 +54,7 @@ def request_mock_setup(requests_mock):
 def area_config_fixture():
     return {
         "manager": "eogrow.core.area.BatchAreaManager",
-        "area": {
-            "filename": "test_large_area.geojson",
-            "buffer": 2,
-            "simplification_factor": 0.1,
-        },
+        "aoi_filename": "test_large_area.geojson",
         "tiling_grid_id": 2,
         "resolution": 120,
         "tile_buffer_x": 10,

--- a/tests/test_core/test_area/test_batch.py
+++ b/tests/test_core/test_area/test_batch.py
@@ -54,7 +54,7 @@ def request_mock_setup(requests_mock):
 def area_config_fixture():
     return {
         "manager": "eogrow.core.area.BatchAreaManager",
-        "aoi_filename": "test_large_area.geojson",
+        "geometry_filename": "test_large_area.geojson",
         "tiling_grid_id": 2,
         "resolution": 120,
         "tile_buffer_x": 10,

--- a/tests/test_core/test_area/test_utm.py
+++ b/tests/test_core/test_area/test_utm.py
@@ -9,7 +9,7 @@ from eogrow.core.area import UtmZoneAreaManager
 @pytest.fixture(scope="session", name="large_area_config")
 def large_area_config_fixture():
     return {
-        "area": {"filename": "test_large_area.geojson", "buffer": 1},
+        "aoi_filename": "test_large_area.geojson",
         "patch": {"size_x": 1000000, "size_y": 1000000, "buffer_x": 0, "buffer_y": 0},
     }
 
@@ -17,7 +17,7 @@ def large_area_config_fixture():
 @pytest.fixture(scope="session", name="area_config")
 def area_config_fixture():
     return {
-        "area": {"filename": "test_area.geojson", "buffer": 0.001},
+        "aoi_filename": "test_area.geojson",
         "patch": {"size_x": 2400, "size_y": 1100, "buffer_x": 120, "buffer_y": 55},
     }
 

--- a/tests/test_core/test_area/test_utm.py
+++ b/tests/test_core/test_area/test_utm.py
@@ -9,7 +9,7 @@ from eogrow.core.area import UtmZoneAreaManager
 @pytest.fixture(scope="session", name="large_area_config")
 def large_area_config_fixture():
     return {
-        "aoi_filename": "test_large_area.geojson",
+        "geometry_filename": "test_large_area.geojson",
         "patch": {"size_x": 1000000, "size_y": 1000000, "buffer_x": 0, "buffer_y": 0},
     }
 
@@ -17,7 +17,7 @@ def large_area_config_fixture():
 @pytest.fixture(scope="session", name="area_config")
 def area_config_fixture():
     return {
-        "aoi_filename": "test_area.geojson",
+        "geometry_filename": "test_area.geojson",
         "patch": {"size_x": 2400, "size_y": 1100, "buffer_x": 120, "buffer_y": 55},
     }
 

--- a/tests/test_utils/test_validators.py
+++ b/tests/test_utils/test_validators.py
@@ -175,7 +175,7 @@ def test_parse_dtype(dtype_input: Union[str, type, np.dtype]):
         (
             {
                 "manager": "eogrow.core.area.BatchAreaManager",
-                "area": {"filename": "some_aoi.geojson"},
+                "aoi_filename": "some_aoi.geojson",
                 "tiling_grid_id": 0,
                 "resolution": 10,
             },

--- a/tests/test_utils/test_validators.py
+++ b/tests/test_utils/test_validators.py
@@ -175,7 +175,7 @@ def test_parse_dtype(dtype_input: Union[str, type, np.dtype]):
         (
             {
                 "manager": "eogrow.core.area.BatchAreaManager",
-                "aoi_filename": "some_aoi.geojson",
+                "geometry_filename": "some_aoi.geojson",
                 "tiling_grid_id": 0,
                 "resolution": 10,
             },


### PR DESCRIPTION
This resolves the area grid cache issue where these parameters were not included in the name.
This MR removes AOI modification, since the user can (and probably should) do it beforehand.

By using a parser-validator I'm able to transfer over data from old-style area configs into the new format. The user gets a deprecation warning. This will give users a bit of time to adapt :)

I am not entirely happy with the `aoi_filename` name, so any suggestions are welcome.

The fact that none of the tests notice a difference just goes to show that it was not very important.