### PR TITLE
Adjust compare content signature

### DIFF
--- a/eogrow/utils/testing.py
+++ b/eogrow/utils/testing.py
@@ -332,42 +332,6 @@ def run_config(
         check_pipeline_logs(pipeline)
 
 
-def compare_content(
-    config_path: str,
-    stats_path: str,
-    *,
-    output_folder_key: Optional[str] = None,
-    save_new_stats: bool = False,
-) -> None:
-    """Compares the results from a pipeline run with the saved statistics
-
-    :param config_path: A path to the config file
-    :param stats_path: A path to the file containing result statistics
-    :param output_folder_key: Type of the folder containing results of the pipeline, inferred from config if missing
-    :param save_new_stats: Save new result stats and skip the comparison
-    """
-    crude_configs = collect_configs_from_path(config_path)
-    raw_configs = [interpret_config_from_dict(config) for config in crude_configs]
-
-    for config in raw_configs:
-        output_folder_key = output_folder_key or config.get("output_folder_key")
-        if output_folder_key is None:
-            raise ValueError("Pipeline does not have an `output_folder_key` parameter, it must be set by hand.")
-
-        pipeline = load_pipeline_class(config).from_raw_config(config)
-        folder = pipeline.storage.get_folder(output_folder_key)
-
-        tester = ContentTester(pipeline.storage.filesystem, folder)
-
-        if save_new_stats:
-            tester.save(stats_path)
-
-        stats_difference = tester.compare(stats_path)
-        if stats_difference:
-            stats_difference_repr = stats_difference.to_json(indent=2, sort_keys=True)
-            raise AssertionError(f"Expected and obtained stats differ:\n{stats_difference_repr}")
-
-
 def extract_output_folder(config_path: str, output_folder_key: Optional[str] = None, full_path: bool = True) -> str:
     """Extracts the path of the pipelines output folder. A folder key can be specified manually.
 
@@ -385,7 +349,7 @@ def extract_output_folder(config_path: str, output_folder_key: Optional[str] = N
     return pipeline.storage.get_folder(output_folder_key, full_path=full_path)
 
 
-def new_compare_content(
+def compare_content(
     folder_path: str,
     stats_path: str,
     *,

--- a/eogrow/utils/testing.py
+++ b/eogrow/utils/testing.py
@@ -345,7 +345,7 @@ def compare_content(
     """Compares the results from a pipeline run with the saved statistics. Constructed to be coupled with `run_config`
     hence the `Optional` input.
 
-    :param folder_path: A path to the folder whose contents are to be compared
+    :param folder_path: A path to the folder with contents to be compared
     :param stats_path: A path to the file containing result statistics
     :param save_new_stats: Save new result stats and skip the comparison
     """

--- a/eogrow/utils/testing.py
+++ b/eogrow/utils/testing.py
@@ -306,8 +306,10 @@ def run_config(
     *,
     output_folder_key: Optional[str] = None,
     reset_output_folder: bool = True,
-) -> None:
-    """Runs a pipeline (or multiple) and checks the logs that all the executions were successful
+) -> Optional[str]:
+    """Runs a pipeline (or multiple) and checks the logs that all the executions were successful. Returns the full path
+    of the output folder (if there is one) so it can be inspected further. In case of chain configs, the output folder
+    of the last config is returned.
 
     :param config_path: A path to the config file
     :param output_folder_key: Type of the folder containing results of the pipeline, inferred from config if None
@@ -331,36 +333,25 @@ def run_config(
 
         check_pipeline_logs(pipeline)
 
-
-def extract_output_folder(config_path: str, output_folder_key: Optional[str] = None, full_path: bool = True) -> str:
-    """Extracts the path of the pipelines output folder. A folder key can be specified manually.
-
-    In the case of config chains, the last key is returned.
-    """
-    crude_configs = collect_configs_from_path(config_path)
-    raw_configs = [interpret_config_from_dict(config) for config in crude_configs]
-    config = raw_configs[-1]
-
-    output_folder_key = output_folder_key or config.get("output_folder_key")
-    if output_folder_key is None:
-        raise ValueError("Pipeline does not have an `output_folder_key` parameter, it must be set by hand.")
-
-    pipeline = load_pipeline_class(config).from_raw_config(config)
-    return pipeline.storage.get_folder(output_folder_key, full_path=full_path)
+    return pipeline.storage.get_folder(output_folder_key, full_path=True) if output_folder_key else None
 
 
 def compare_content(
-    folder_path: str,
+    folder_path: Optional[str],
     stats_path: str,
     *,
     save_new_stats: bool = False,
 ) -> None:
-    """Compares the results from a pipeline run with the saved statistics
+    """Compares the results from a pipeline run with the saved statistics. Constructed to be coupled with `run_config`
+    hence the `Optional` input.
 
     :param folder_path: A path to the folder whose contents are to be compared
     :param stats_path: A path to the file containing result statistics
     :param save_new_stats: Save new result stats and skip the comparison
     """
+    if folder_path is None:
+        raise ValueError("The given path is None. The pipeline likely has no `output_folder_key` parameter.")
+
     tester = ContentTester(OSFS("/"), folder_path)
 
     if save_new_stats:

--- a/eogrow/utils/testing.py
+++ b/eogrow/utils/testing.py
@@ -13,6 +13,7 @@ import rasterio
 import shapely.ops
 from deepdiff import DeepDiff
 from fs.base import FS
+from fs.osfs import OSFS
 
 from eolearn.core import EOPatch, FeatureType
 from eolearn.core.eodata_io import get_filesystem_data_info
@@ -365,6 +366,46 @@ def compare_content(
         if stats_difference:
             stats_difference_repr = stats_difference.to_json(indent=2, sort_keys=True)
             raise AssertionError(f"Expected and obtained stats differ:\n{stats_difference_repr}")
+
+
+def extract_output_folder(config_path: str, output_folder_key: Optional[str] = None, full_path: bool = True) -> str:
+    """Extracts the path of the pipelines output folder. A folder key can be specified manually.
+
+    In the case of config chains, the last key is returned.
+    """
+    crude_configs = collect_configs_from_path(config_path)
+    raw_configs = [interpret_config_from_dict(config) for config in crude_configs]
+    config = raw_configs[-1]
+
+    output_folder_key = output_folder_key or config.get("output_folder_key")
+    if output_folder_key is None:
+        raise ValueError("Pipeline does not have an `output_folder_key` parameter, it must be set by hand.")
+
+    pipeline = load_pipeline_class(config).from_raw_config(config)
+    return pipeline.storage.get_folder(output_folder_key, full_path=full_path)
+
+
+def new_compare_content(
+    folder_path: str,
+    stats_path: str,
+    *,
+    save_new_stats: bool = False,
+) -> None:
+    """Compares the results from a pipeline run with the saved statistics
+
+    :param folder_path: A path to the folder whose contents are to be compared
+    :param stats_path: A path to the file containing result statistics
+    :param save_new_stats: Save new result stats and skip the comparison
+    """
+    tester = ContentTester(OSFS("/"), folder_path)
+
+    if save_new_stats:
+        tester.save(stats_path)
+
+    stats_difference = tester.compare(stats_path)
+    if stats_difference:
+        stats_difference_repr = stats_difference.to_json(indent=2, sort_keys=True)
+        raise AssertionError(f"Expected and obtained stats differ:\n{stats_difference_repr}")
 
 
 def run_and_test_pipeline(

--- a/tests/test_pipelines/test_batch_to_eopatch.py
+++ b/tests/test_pipelines/test_batch_to_eopatch.py
@@ -10,7 +10,7 @@ from fs.base import FS
 from sentinelhub import BBox
 
 from eogrow.pipelines.batch_to_eopatch import BatchToEOPatchPipeline
-from eogrow.utils.testing import compare_content, generate_tiff_file, run_config
+from eogrow.utils.testing import extract_output_folder, generate_tiff_file, new_compare_content, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -77,4 +77,4 @@ def test_batch_to_eopatch_pipeline(config_and_stats_paths, experiment_name):
         )
 
     run_config(config_path)
-    compare_content(config_path, stats_path)
+    new_compare_content(extract_output_folder(config_path), stats_path)

--- a/tests/test_pipelines/test_batch_to_eopatch.py
+++ b/tests/test_pipelines/test_batch_to_eopatch.py
@@ -10,7 +10,7 @@ from fs.base import FS
 from sentinelhub import BBox
 
 from eogrow.pipelines.batch_to_eopatch import BatchToEOPatchPipeline
-from eogrow.utils.testing import compare_content, extract_output_folder, generate_tiff_file, run_config
+from eogrow.utils.testing import compare_content, generate_tiff_file, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -76,5 +76,5 @@ def test_batch_to_eopatch_pipeline(config_and_stats_paths, experiment_name):
             timestamp_shuffle_seed=17,
         )
 
-    run_config(config_path)
-    compare_content(extract_output_folder(config_path), stats_path)
+    output_path = run_config(config_path)
+    compare_content(output_path, stats_path)

--- a/tests/test_pipelines/test_batch_to_eopatch.py
+++ b/tests/test_pipelines/test_batch_to_eopatch.py
@@ -10,7 +10,7 @@ from fs.base import FS
 from sentinelhub import BBox
 
 from eogrow.pipelines.batch_to_eopatch import BatchToEOPatchPipeline
-from eogrow.utils.testing import extract_output_folder, generate_tiff_file, new_compare_content, run_config
+from eogrow.utils.testing import compare_content, extract_output_folder, generate_tiff_file, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -77,4 +77,4 @@ def test_batch_to_eopatch_pipeline(config_and_stats_paths, experiment_name):
         )
 
     run_config(config_path)
-    new_compare_content(extract_output_folder(config_path), stats_path)
+    compare_content(extract_output_folder(config_path), stats_path)

--- a/tests/test_pipelines/test_download.py
+++ b/tests/test_pipelines/test_download.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
-from eogrow.utils.testing import extract_output_folder, new_compare_content, run_config
+from eogrow.utils.testing import compare_content, extract_output_folder, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -29,7 +29,7 @@ def test_preparation(storage):
 def test_download_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("download_and_batch", experiment_name)
     run_config(config_path)
-    new_compare_content(extract_output_folder(config_path), stats_path)
+    compare_content(extract_output_folder(config_path), stats_path)
 
 
 @pytest.mark.parametrize("experiment_name", ["download_custom_raise"])

--- a/tests/test_pipelines/test_download.py
+++ b/tests/test_pipelines/test_download.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
-from eogrow.utils.testing import compare_content, run_config
+from eogrow.utils.testing import extract_output_folder, new_compare_content, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -29,7 +29,7 @@ def test_preparation(storage):
 def test_download_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("download_and_batch", experiment_name)
     run_config(config_path)
-    compare_content(config_path, stats_path)
+    new_compare_content(extract_output_folder(config_path), stats_path)
 
 
 @pytest.mark.parametrize("experiment_name", ["download_custom_raise"])

--- a/tests/test_pipelines/test_download.py
+++ b/tests/test_pipelines/test_download.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
-from eogrow.utils.testing import compare_content, extract_output_folder, run_config
+from eogrow.utils.testing import compare_content, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -28,8 +28,8 @@ def test_preparation(storage):
 )
 def test_download_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("download_and_batch", experiment_name)
-    run_config(config_path)
-    compare_content(extract_output_folder(config_path), stats_path)
+    output_path = run_config(config_path)
+    compare_content(output_path, stats_path)
 
 
 @pytest.mark.parametrize("experiment_name", ["download_custom_raise"])

--- a/tests/test_pipelines/test_export_maps.py
+++ b/tests/test_pipelines/test_export_maps.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import extract_output_folder, new_compare_content, run_config
+from eogrow.utils.testing import compare_content, extract_output_folder, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -18,4 +18,4 @@ pytestmark = pytest.mark.integration
 def test_export_maps_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("export_maps", experiment_name)
     run_config(config_path)
-    new_compare_content(extract_output_folder(config_path), stats_path)
+    compare_content(extract_output_folder(config_path), stats_path)

--- a/tests/test_pipelines/test_export_maps.py
+++ b/tests/test_pipelines/test_export_maps.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import compare_content, extract_output_folder, run_config
+from eogrow.utils.testing import compare_content, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -17,5 +17,5 @@ pytestmark = pytest.mark.integration
 )
 def test_export_maps_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("export_maps", experiment_name)
-    run_config(config_path)
-    compare_content(extract_output_folder(config_path), stats_path)
+    output_path = run_config(config_path)
+    compare_content(output_path, stats_path)

--- a/tests/test_pipelines/test_export_maps.py
+++ b/tests/test_pipelines/test_export_maps.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import compare_content, run_config
+from eogrow.utils.testing import extract_output_folder, new_compare_content, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -18,4 +18,4 @@ pytestmark = pytest.mark.integration
 def test_export_maps_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("export_maps", experiment_name)
     run_config(config_path)
-    compare_content(config_path, stats_path)
+    new_compare_content(extract_output_folder(config_path), stats_path)

--- a/tests/test_pipelines/test_features.py
+++ b/tests/test_pipelines/test_features.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import compare_content, extract_output_folder, run_config
+from eogrow.utils.testing import compare_content, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -19,5 +19,5 @@ pytestmark = pytest.mark.integration
 )
 def test_features_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("features", experiment_name)
-    run_config(config_path)
-    compare_content(extract_output_folder(config_path), stats_path)
+    output_path = run_config(config_path)
+    compare_content(output_path, stats_path)

--- a/tests/test_pipelines/test_features.py
+++ b/tests/test_pipelines/test_features.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import compare_content, run_config
+from eogrow.utils.testing import extract_output_folder, new_compare_content, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -20,4 +20,4 @@ pytestmark = pytest.mark.integration
 def test_features_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("features", experiment_name)
     run_config(config_path)
-    compare_content(config_path, stats_path)
+    new_compare_content(extract_output_folder(config_path), stats_path)

--- a/tests/test_pipelines/test_features.py
+++ b/tests/test_pipelines/test_features.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import extract_output_folder, new_compare_content, run_config
+from eogrow.utils.testing import compare_content, extract_output_folder, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -20,4 +20,4 @@ pytestmark = pytest.mark.integration
 def test_features_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("features", experiment_name)
     run_config(config_path)
-    new_compare_content(extract_output_folder(config_path), stats_path)
+    compare_content(extract_output_folder(config_path), stats_path)

--- a/tests/test_pipelines/test_import_tiff.py
+++ b/tests/test_pipelines/test_import_tiff.py
@@ -25,8 +25,8 @@ def test_import_tiff_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("import_tiff", experiment_name)
 
     prepare_dummy_input(config_path)
-    run_config(config_path)
-    compare_content(config_path, stats_path)
+    output_path = run_config(config_path)
+    compare_content(output_path, stats_path)
 
 
 def prepare_dummy_input(config_path: str) -> None:

--- a/tests/test_pipelines/test_import_vector.py
+++ b/tests/test_pipelines/test_import_vector.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import compare_content, run_config
+from eogrow.utils.testing import extract_output_folder, new_compare_content, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -10,4 +10,4 @@ pytestmark = pytest.mark.integration
 def test_import_tiff_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("import_vector", experiment_name)
     run_config(config_path)
-    compare_content(config_path, stats_path)
+    new_compare_content(extract_output_folder(config_path), stats_path)

--- a/tests/test_pipelines/test_import_vector.py
+++ b/tests/test_pipelines/test_import_vector.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import compare_content, extract_output_folder, run_config
+from eogrow.utils.testing import compare_content, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -9,5 +9,5 @@ pytestmark = pytest.mark.integration
 @pytest.mark.parametrize("experiment_name", ["import_vector", "import_vector_temporal"])
 def test_import_tiff_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("import_vector", experiment_name)
-    run_config(config_path)
-    compare_content(extract_output_folder(config_path), stats_path)
+    output_path = run_config(config_path)
+    compare_content(output_path, stats_path)

--- a/tests/test_pipelines/test_import_vector.py
+++ b/tests/test_pipelines/test_import_vector.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import extract_output_folder, new_compare_content, run_config
+from eogrow.utils.testing import compare_content, extract_output_folder, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -10,4 +10,4 @@ pytestmark = pytest.mark.integration
 def test_import_tiff_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("import_vector", experiment_name)
     run_config(config_path)
-    new_compare_content(extract_output_folder(config_path), stats_path)
+    compare_content(extract_output_folder(config_path), stats_path)

--- a/tests/test_pipelines/test_merge_samples.py
+++ b/tests/test_pipelines/test_merge_samples.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import compare_content, extract_output_folder, run_config
+from eogrow.utils.testing import compare_content, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -13,5 +13,5 @@ pytestmark = pytest.mark.integration
 )
 def test_merge_samples_pipeline(config_and_stats_paths, experiment_name, reset_folder):
     config_path, stats_path = config_and_stats_paths("merge_samples", experiment_name)
-    run_config(config_path, reset_output_folder=reset_folder)
-    compare_content(extract_output_folder(config_path), stats_path)
+    output_path = run_config(config_path, reset_output_folder=reset_folder)
+    compare_content(output_path, stats_path)

--- a/tests/test_pipelines/test_merge_samples.py
+++ b/tests/test_pipelines/test_merge_samples.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import extract_output_folder, new_compare_content, run_config
+from eogrow.utils.testing import compare_content, extract_output_folder, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -14,4 +14,4 @@ pytestmark = pytest.mark.integration
 def test_merge_samples_pipeline(config_and_stats_paths, experiment_name, reset_folder):
     config_path, stats_path = config_and_stats_paths("merge_samples", experiment_name)
     run_config(config_path, reset_output_folder=reset_folder)
-    new_compare_content(extract_output_folder(config_path), stats_path)
+    compare_content(extract_output_folder(config_path), stats_path)

--- a/tests/test_pipelines/test_merge_samples.py
+++ b/tests/test_pipelines/test_merge_samples.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import compare_content, run_config
+from eogrow.utils.testing import extract_output_folder, new_compare_content, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -14,4 +14,4 @@ pytestmark = pytest.mark.integration
 def test_merge_samples_pipeline(config_and_stats_paths, experiment_name, reset_folder):
     config_path, stats_path = config_and_stats_paths("merge_samples", experiment_name)
     run_config(config_path, reset_output_folder=reset_folder)
-    compare_content(config_path, stats_path)
+    new_compare_content(extract_output_folder(config_path), stats_path)

--- a/tests/test_pipelines/test_prediction.py
+++ b/tests/test_pipelines/test_prediction.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import compare_content, extract_output_folder, run_config
+from eogrow.utils.testing import compare_content, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -17,5 +17,5 @@ pytestmark = pytest.mark.integration
 )
 def test_prediction_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("prediction", experiment_name)
-    run_config(config_path)
-    compare_content(extract_output_folder(config_path), stats_path)
+    output_path = run_config(config_path)
+    compare_content(output_path, stats_path)

--- a/tests/test_pipelines/test_prediction.py
+++ b/tests/test_pipelines/test_prediction.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import compare_content, run_config
+from eogrow.utils.testing import extract_output_folder, new_compare_content, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -18,4 +18,4 @@ pytestmark = pytest.mark.integration
 def test_prediction_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("prediction", experiment_name)
     run_config(config_path)
-    compare_content(config_path, stats_path)
+    new_compare_content(extract_output_folder(config_path), stats_path)

--- a/tests/test_pipelines/test_prediction.py
+++ b/tests/test_pipelines/test_prediction.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import extract_output_folder, new_compare_content, run_config
+from eogrow.utils.testing import compare_content, extract_output_folder, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -18,4 +18,4 @@ pytestmark = pytest.mark.integration
 def test_prediction_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("prediction", experiment_name)
     run_config(config_path)
-    new_compare_content(extract_output_folder(config_path), stats_path)
+    compare_content(extract_output_folder(config_path), stats_path)

--- a/tests/test_pipelines/test_sampling.py
+++ b/tests/test_pipelines/test_sampling.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import compare_content, extract_output_folder, run_config
+from eogrow.utils.testing import compare_content, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -18,5 +18,5 @@ pytestmark = pytest.mark.integration
 )
 def test_sampling_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("sampling", experiment_name)
-    run_config(config_path)
-    compare_content(extract_output_folder(config_path), stats_path)
+    output_path = run_config(config_path)
+    compare_content(output_path, stats_path)

--- a/tests/test_pipelines/test_sampling.py
+++ b/tests/test_pipelines/test_sampling.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import compare_content, run_config
+from eogrow.utils.testing import extract_output_folder, new_compare_content, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -19,4 +19,4 @@ pytestmark = pytest.mark.integration
 def test_sampling_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("sampling", experiment_name)
     run_config(config_path)
-    compare_content(config_path, stats_path)
+    new_compare_content(extract_output_folder(config_path), stats_path)

--- a/tests/test_pipelines/test_sampling.py
+++ b/tests/test_pipelines/test_sampling.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import extract_output_folder, new_compare_content, run_config
+from eogrow.utils.testing import compare_content, extract_output_folder, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -19,4 +19,4 @@ pytestmark = pytest.mark.integration
 def test_sampling_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("sampling", experiment_name)
     run_config(config_path)
-    new_compare_content(extract_output_folder(config_path), stats_path)
+    compare_content(extract_output_folder(config_path), stats_path)

--- a/tests/test_pipelines/test_split_grid.py
+++ b/tests/test_pipelines/test_split_grid.py
@@ -4,7 +4,7 @@ import shutil
 import pytest
 
 from eogrow.core.area import CustomGridAreaManager
-from eogrow.utils.testing import compare_content, extract_output_folder, run_config
+from eogrow.utils.testing import compare_content, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -32,8 +32,8 @@ def test_grid_splitting(config_and_stats_paths, preparation_config, config, batc
     config_path, stats_path = config_and_stats_paths("split_grid", config)
 
     run_config(preparation_config_path)
-    run_config(config_path, output_folder_key="output_folder")
-    compare_content(extract_output_folder(config_path, output_folder_key="output_folder"), stats_path)
+    output_path = run_config(config_path, output_folder_key="output_folder")
+    compare_content(output_path, stats_path)
 
     # check the output file is compatible with custom grid area managers
     new_area_manager = CustomGridAreaManager.from_raw_config(

--- a/tests/test_pipelines/test_split_grid.py
+++ b/tests/test_pipelines/test_split_grid.py
@@ -4,7 +4,7 @@ import shutil
 import pytest
 
 from eogrow.core.area import CustomGridAreaManager
-from eogrow.utils.testing import compare_content, run_config
+from eogrow.utils.testing import extract_output_folder, new_compare_content, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -33,7 +33,7 @@ def test_grid_splitting(config_and_stats_paths, preparation_config, config, batc
 
     run_config(preparation_config_path)
     run_config(config_path, output_folder_key="output_folder")
-    compare_content(config_path, stats_path, output_folder_key="output_folder")
+    new_compare_content(extract_output_folder(config_path, output_folder_key="output_folder"), stats_path)
 
     # check the output file is compatible with custom grid area managers
     new_area_manager = CustomGridAreaManager.from_raw_config(

--- a/tests/test_pipelines/test_split_grid.py
+++ b/tests/test_pipelines/test_split_grid.py
@@ -4,7 +4,7 @@ import shutil
 import pytest
 
 from eogrow.core.area import CustomGridAreaManager
-from eogrow.utils.testing import extract_output_folder, new_compare_content, run_config
+from eogrow.utils.testing import compare_content, extract_output_folder, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -33,7 +33,7 @@ def test_grid_splitting(config_and_stats_paths, preparation_config, config, batc
 
     run_config(preparation_config_path)
     run_config(config_path, output_folder_key="output_folder")
-    new_compare_content(extract_output_folder(config_path, output_folder_key="output_folder"), stats_path)
+    compare_content(extract_output_folder(config_path, output_folder_key="output_folder"), stats_path)
 
     # check the output file is compatible with custom grid area managers
     new_area_manager = CustomGridAreaManager.from_raw_config(

--- a/tests/test_pipelines/test_testing.py
+++ b/tests/test_pipelines/test_testing.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import extract_output_folder, new_compare_content, run_config
+from eogrow.utils.testing import compare_content, extract_output_folder, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -10,4 +10,4 @@ pytestmark = pytest.mark.integration
 def test_features_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("testing", experiment_name)
     run_config(config_path)
-    new_compare_content(extract_output_folder(config_path), stats_path)
+    compare_content(extract_output_folder(config_path), stats_path)

--- a/tests/test_pipelines/test_testing.py
+++ b/tests/test_pipelines/test_testing.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import compare_content, run_config
+from eogrow.utils.testing import extract_output_folder, new_compare_content, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -10,4 +10,4 @@ pytestmark = pytest.mark.integration
 def test_features_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("testing", experiment_name)
     run_config(config_path)
-    compare_content(config_path, stats_path)
+    new_compare_content(extract_output_folder(config_path), stats_path)

--- a/tests/test_pipelines/test_testing.py
+++ b/tests/test_pipelines/test_testing.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import compare_content, extract_output_folder, run_config
+from eogrow.utils.testing import compare_content, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -9,5 +9,5 @@ pytestmark = pytest.mark.integration
 @pytest.mark.parametrize("experiment_name", ["testing", "timestamps_only"])
 def test_features_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("testing", experiment_name)
-    run_config(config_path)
-    compare_content(extract_output_folder(config_path), stats_path)
+    output_path = run_config(config_path)
+    compare_content(output_path, stats_path)

--- a/tests/test_pipelines/test_zipmap.py
+++ b/tests/test_pipelines/test_zipmap.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import compare_content, run_config
+from eogrow.utils.testing import extract_output_folder, new_compare_content, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -10,4 +10,4 @@ pytestmark = pytest.mark.integration
 def test_zipmap_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("zipmap", experiment_name)
     run_config(config_path)
-    compare_content(config_path, stats_path)
+    new_compare_content(extract_output_folder(config_path), stats_path)

--- a/tests/test_pipelines/test_zipmap.py
+++ b/tests/test_pipelines/test_zipmap.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import compare_content, extract_output_folder, run_config
+from eogrow.utils.testing import compare_content, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -9,5 +9,5 @@ pytestmark = pytest.mark.integration
 @pytest.mark.parametrize("experiment_name", [pytest.param("zipmap", marks=pytest.mark.chain)])
 def test_zipmap_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("zipmap", experiment_name)
-    run_config(config_path)
-    compare_content(extract_output_folder(config_path), stats_path)
+    output_path = run_config(config_path)
+    compare_content(output_path, stats_path)

--- a/tests/test_pipelines/test_zipmap.py
+++ b/tests/test_pipelines/test_zipmap.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eogrow.utils.testing import extract_output_folder, new_compare_content, run_config
+from eogrow.utils.testing import compare_content, extract_output_folder, run_config
 
 pytestmark = pytest.mark.integration
 
@@ -10,4 +10,4 @@ pytestmark = pytest.mark.integration
 def test_zipmap_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("zipmap", experiment_name)
     run_config(config_path)
-    new_compare_content(extract_output_folder(config_path), stats_path)
+    compare_content(extract_output_folder(config_path), stats_path)

--- a/tests/test_pipelines/test_zipmap.py
+++ b/tests/test_pipelines/test_zipmap.py
@@ -5,7 +5,7 @@ from eogrow.utils.testing import compare_content, run_config
 pytestmark = pytest.mark.integration
 
 
-@pytest.mark.order(after=["test_prediction.py::test_rasterization_pipeline"])
+@pytest.mark.order(after=["test_rasterize.py::test_rasterize_pipeline"])
 @pytest.mark.parametrize("experiment_name", [pytest.param("zipmap", marks=pytest.mark.chain)])
 def test_zipmap_pipeline(config_and_stats_paths, experiment_name):
     config_path, stats_path = config_and_stats_paths("zipmap", experiment_name)


### PR DESCRIPTION
Compare content should be more explicit about the fact that it wants a folder.
And `run_config` can output the final folder path.

This should make it easier for more exotic test setups.