### PR TITLE
Refactor RasterizePipeline and tests

### DIFF
--- a/eogrow/pipelines/rasterize.py
+++ b/eogrow/pipelines/rasterize.py
@@ -152,10 +152,9 @@ class RasterizePipeline(Pipeline):
             ]
 
         dataset_gdf = concat_gdf(dataset_layers, reproject_crs=preprocess_config.reproject_crs)
-
         dataset_gdf = self.preprocess_dataset(dataset_gdf)
-
         dataset_path = self._get_dataset_path(filename)
+
         with LocalFile(dataset_path, mode="w", filesystem=self.storage.filesystem) as local_file:
             dataset_gdf.to_file(local_file.path, encoding="utf-8", driver="GPKG", engine=gpd_engine)
 
@@ -190,9 +189,7 @@ class RasterizePipeline(Pipeline):
             data_preparation_node = EONode(input_task)
 
         preprocess_node = self.get_prerasterization_node(data_preparation_node)
-
         rasterization_node = self.get_rasterization_node(preprocess_node)
-
         postprocess_node = self.get_postrasterization_node(rasterization_node)
 
         save_task = SaveTask(
@@ -236,13 +233,6 @@ class RasterizePipeline(Pipeline):
     def get_postrasterization_node(self, previous_node: EONode) -> EONode:  # pylint: disable=no-self-use
         """Builds node with tasks to be applied after rasterization"""
         return previous_node
-
-    @staticmethod
-    def _parse_input_file(value: str) -> str:
-        """Checks if given name ends with one of the supported file extensions"""
-        if not value.lower().endswith((".geojson", ".shp", ".gpkg", ".gdb")):
-            raise ValueError(f"Input file path {value} should be a GeoJSON, Shapefile, GeoPackage or GeoDataBase.")
-        return value
 
     def _get_dataset_path(self, filename: str) -> str:
         """Provides a path from where dataset should be loaded into the workflow"""

--- a/eogrow/pipelines/rasterize.py
+++ b/eogrow/pipelines/rasterize.py
@@ -52,7 +52,7 @@ class RasterizePipeline(Pipeline):
             description="In case of multi-layer files, name of the layer with data to be rasterized."
         )
         raster_value: Optional[float] = Field(
-            description="Value to be used for all rasterized polygons. Use either this or `values_column`."
+            description="Value to be used for all rasterized polygons. Use either this or `raster_values_column`."
         )
         raster_values_column: Optional[str] = Field(
             description=(

--- a/eogrow/pipelines/rasterize.py
+++ b/eogrow/pipelines/rasterize.py
@@ -19,7 +19,7 @@ from ..core.schemas import BaseSchema
 from ..types import Feature, FeatureSpec, PatchList
 from ..utils.filter import get_patches_with_missing_features
 from ..utils.fs import LocalFile
-from ..utils.validators import ensure_exactly_one_defined, field_validator, parse_dtype
+from ..utils.validators import ensure_exactly_one_defined, field_validator, parse_dtype, restrict_types
 from ..utils.vector import concat_gdf
 
 LOGGER = logging.getLogger(__name__)
@@ -51,6 +51,7 @@ class RasterOutputSchema(BaseSchema):
     _parse_dtype = field_validator("dtype", parse_dtype, pre=True)
     _check_value_values_column = ensure_exactly_one_defined("value", "values_column")
     _check_shape_resolution = ensure_exactly_one_defined("raster_shape", "resolution")
+    _check_feature_type = field_validator("feature", restrict_types(lambda ftype: ftype.is_image()))
 
 
 class Preprocessing(BaseSchema):

--- a/eogrow/pipelines/rasterize.py
+++ b/eogrow/pipelines/rasterize.py
@@ -8,7 +8,7 @@ import fiona
 import fs
 import geopandas as gpd
 import numpy as np
-from pydantic import Field, root_validator
+from pydantic import Field, validator
 
 from eolearn.core import CreateEOPatchTask, EONode, EOWorkflow, FeatureType, LoadTask, OverwritePermission, SaveTask
 from eolearn.core.utils.parsing import parse_feature
@@ -20,7 +20,7 @@ from ..core.schemas import BaseSchema
 from ..types import Feature, FeatureSpec, PatchList
 from ..utils.filter import get_patches_with_missing_features
 from ..utils.fs import LocalFile
-from ..utils.validators import ensure_exactly_one_defined, field_validator, parse_dtype
+from ..utils.validators import ensure_exactly_one_defined, field_validator, parse_dtype, restrict_types
 from ..utils.vector import concat_gdf
 
 LOGGER = logging.getLogger(__name__)
@@ -82,12 +82,10 @@ class RasterizePipeline(Pipeline):
         _parse_dtype = field_validator("dtype", parse_dtype, pre=True)
         _check_raster_value_values_column = ensure_exactly_one_defined("raster_value", "raster_values_column")
         _check_shape_resolution = ensure_exactly_one_defined("raster_shape", "resolution")
+        _check_output_feature_type = field_validator("output_feature", restrict_types(lambda ftype: ftype.is_image()))
 
-        @root_validator
-        def _check_input_output(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-            vector_input: Union[Feature, str] = values["vector_input"]
-            raster_feature: Feature = values["raster_feature"]
-            parse_feature(feature=raster_feature, allowed_feature_types=lambda ftype: ftype.is_image())
+        @validator("vector_input")
+        def _check_vector_input(cls, vector_input: Union[Feature, str]) -> Union[Feature, str]:
             if isinstance(vector_input, str):
                 if not vector_input.lower().endswith((".geojson", ".shp", ".gpkg", ".gdb")):
                     raise ValueError(
@@ -95,11 +93,17 @@ class RasterizePipeline(Pipeline):
                     )
             else:
                 parse_feature(feature=vector_input, allowed_feature_types=lambda ftype: ftype.is_vector())
+            return vector_input
+
+        @validator("output_feature")
+        def _check_temporal_nature_match(cls, output_feature: Feature, values: Dict[str, Any]) -> Feature:
+            vector_input: Union[Feature, str] = values["vector_input"]
+            if not isinstance(vector_input, str):
                 vector_ftype, _ = vector_input
-                raster_ftype, _ = raster_feature
+                raster_ftype, _ = output_feature
                 if vector_ftype.is_temporal() != raster_ftype.is_temporal():
                     raise ValueError("Temporal natures of the vector input and the raster output don't match!")
-            return values
+            return output_feature
 
     config: Schema
 

--- a/eogrow/pipelines/rasterize.py
+++ b/eogrow/pipelines/rasterize.py
@@ -112,19 +112,16 @@ class RasterizePipeline(Pipeline):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 
-        self.filename: Optional[str] = None
+        raster_feature = self.config.raster_feature
+        vector_ftype = FeatureType.VECTOR if self._is_temporal(raster_feature) else FeatureType.VECTOR_TIMELESS
 
-        output_is_temporal = self._is_temporal(self.config.raster_feature)
+        self.filename: Optional[str] = None
+        self.vector_feature: Feature
+
         if isinstance(self.config.vector_input, str):
-            self.filename = self._parse_input_file(self.config.vector_input)
-            feature_type = FeatureType.VECTOR if output_is_temporal else FeatureType.VECTOR_TIMELESS
-            self.vector_feature = feature_type, f"TEMP_{uuid.uuid4().hex}"
+            self.filename = self.config.vector_input
+            self.vector_feature = (vector_ftype, f"TEMP_{uuid.uuid4().hex}")
         else:
-            if output_is_temporal != self._is_temporal(self.config.vector_input):
-                raise ValueError(
-                    "The requested output feature does not correspond to input vector feature."
-                    " Both input and output should be the same, either temporal or timeless."
-                )
             self.vector_feature = self.config.vector_input
 
     def filter_patch_list(self, patch_list: PatchList) -> PatchList:

--- a/tests/test_config_files/rasterize/base_rasterize_pipeline.json
+++ b/tests/test_config_files/rasterize/base_rasterize_pipeline.json
@@ -1,0 +1,8 @@
+{
+  "pipeline": "eogrow.pipelines.rasterize.RasterizePipeline",
+  "**global_config": "${config_path}/../global_config.json",
+  "input_folder_key": "input_data",
+  "output_folder_key": "reference",
+  "vector_input": "test_area_crops.geojson",
+  "preprocess_dataset": {}
+}

--- a/tests/test_config_files/rasterize/base_rasterize_pipeline_features.json
+++ b/tests/test_config_files/rasterize/base_rasterize_pipeline_features.json
@@ -1,0 +1,11 @@
+{
+  "pipeline": "eogrow.pipelines.rasterize.RasterizePipeline",
+  "**global_config": "${config_path}/../global_config.json",
+  "input_folder_key": "reference",  // This one rasterizes from a vector feature, that is added in tests
+  "output_folder_key": "reference",
+  "vector_input": ["vector_timeless", "LULC_VECTOR"],
+  "resolution": 10,
+  "overlap_value": 0,
+  "dtype": "int16",
+  "workers": 2
+}

--- a/tests/test_config_files/rasterize/base_rasterize_pipeline_float.json
+++ b/tests/test_config_files/rasterize/base_rasterize_pipeline_float.json
@@ -1,0 +1,8 @@
+{
+  "pipeline": "eogrow.pipelines.rasterize.RasterizePipeline",
+  "**global_config": "${config_path}/../global_config.json",
+  "input_folder_key": "input_data",
+  "output_folder_key": "temp",
+  "vector_input": "test_area_crops.geojson",
+  "preprocess_dataset": {}
+}

--- a/tests/test_config_files/rasterize/rasterize_pipeline.json
+++ b/tests/test_config_files/rasterize/rasterize_pipeline.json
@@ -1,20 +1,14 @@
-{
-  "pipeline": "eogrow.pipelines.rasterize.RasterizePipeline",
-  "**global_config": "${config_path}/../global_config.json",
-  "input_folder_key": "input_data",
-  "output_folder_key": "reference",
-  "vector_input": "test_area_crops.geojson",
-  "columns": [
-    {
-      "values_column": "CROP_ID",
-      "output_feature": ["mask_timeless", "CROP_ID"],
-      "resolution": 10
-    },
-    {
-      "values_column": "POLYGON_ID",
-      "output_feature": ["mask_timeless", "POLYGON_ID"],
-      "raster_shape": [121, 264]
-    }
-  ],
-  "preprocess_dataset": {}
-}
+[
+  {
+    "raster_values_column": "CROP_ID",
+    "raster_feature": ["mask_timeless", "CROP_ID"],
+    "resolution": 10,
+    "**rasterize_base": "${config_path}/base_rasterize_pipeline.json"
+  },
+  {
+    "raster_values_column": "POLYGON_ID",
+    "raster_feature": ["mask_timeless", "POLYGON_ID"],
+    "raster_shape": [121, 264],
+    "**rasterize_base": "${config_path}/base_rasterize_pipeline.json"
+  }
+]

--- a/tests/test_config_files/rasterize/rasterize_pipeline.json
+++ b/tests/test_config_files/rasterize/rasterize_pipeline.json
@@ -1,13 +1,13 @@
 [
   {
     "raster_values_column": "CROP_ID",
-    "raster_feature": ["mask_timeless", "CROP_ID"],
+    "output_feature": ["mask_timeless", "CROP_ID"],
     "resolution": 10,
     "**rasterize_base": "${config_path}/base_rasterize_pipeline.json"
   },
   {
     "raster_values_column": "POLYGON_ID",
-    "raster_feature": ["mask_timeless", "POLYGON_ID"],
+    "output_feature": ["mask_timeless", "POLYGON_ID"],
     "raster_shape": [121, 264],
     "**rasterize_base": "${config_path}/base_rasterize_pipeline.json"
   }

--- a/tests/test_config_files/rasterize/rasterize_pipeline_features.json
+++ b/tests/test_config_files/rasterize/rasterize_pipeline_features.json
@@ -1,40 +1,24 @@
-{
-  "pipeline": "eogrow.pipelines.rasterize.RasterizePipeline",
-  "**global_config": "${config_path}/../global_config.json",
-  "input_folder_key": "reference",  // This one rasterizes from a vector feature, that is added in tests
-  "output_folder_key": "reference",
-  "vector_input": ["vector_timeless", "LULC_VECTOR"],
-  "columns": [
-    {
-      "values_column": "LULC_ID",
-      "output_feature": ["mask_timeless", "LULC_ID"],
-      "resolution": 10,
-      "overlap_value": 0,
-      "dtype": "int16"
-    },
-    {
-      "values_column": "LULC_POLYGON_ID",
-      "output_feature": ["mask_timeless", "LULC_POLYGON_ID"],
-      "resolution": 10,
-      "overlap_value": 0,
-      "dtype": "int16"
-    },
-    {
-      "values_column": "LULC_POLYGON_ID",
-      "output_feature": ["mask_timeless", "LULC_POLYGON_ERODED_01"],
-      "resolution": 10,
-      "dtype": "int16",
-      "overlap_value": 0,
-      "polygon_buffer": -10
-    },
-    {
-      "values_column": "LULC_POLYGON_ID",
-      "output_feature": ["mask_timeless", "LULC_POLYGON_ERODED_02"],
-      "resolution": 10,
-      "dtype": "int16",
-      "overlap_value": 0,
-      "polygon_buffer": -15
-    }
-  ],
-  "workers": 2
-}
+[
+  {
+    "raster_values_column": "LULC_ID",
+    "raster_feature": ["mask_timeless", "LULC_ID"],
+    "**rasterize_base": "${config_path}/base_rasterize_pipeline_features.json"
+  },
+  {
+    "raster_values_column": "LULC_POLYGON_ID",
+    "raster_feature": ["mask_timeless", "LULC_POLYGON_ID"],
+    "**rasterize_base": "${config_path}/base_rasterize_pipeline_features.json"
+  },
+  {
+    "raster_values_column": "LULC_POLYGON_ID",
+    "raster_feature": ["mask_timeless", "LULC_POLYGON_ERODED_01"],
+    "polygon_buffer": -10,
+    "**rasterize_base": "${config_path}/base_rasterize_pipeline_features.json"
+  },
+  {
+    "raster_values_column": "LULC_POLYGON_ID",
+    "raster_feature": ["mask_timeless", "LULC_POLYGON_ERODED_02"],
+    "polygon_buffer": -15,
+    "**rasterize_base": "${config_path}/base_rasterize_pipeline_features.json"
+  }
+]

--- a/tests/test_config_files/rasterize/rasterize_pipeline_features.json
+++ b/tests/test_config_files/rasterize/rasterize_pipeline_features.json
@@ -1,23 +1,23 @@
 [
   {
     "raster_values_column": "LULC_ID",
-    "raster_feature": ["mask_timeless", "LULC_ID"],
+    "output_feature": ["mask_timeless", "LULC_ID"],
     "**rasterize_base": "${config_path}/base_rasterize_pipeline_features.json"
   },
   {
     "raster_values_column": "LULC_POLYGON_ID",
-    "raster_feature": ["mask_timeless", "LULC_POLYGON_ID"],
+    "output_feature": ["mask_timeless", "LULC_POLYGON_ID"],
     "**rasterize_base": "${config_path}/base_rasterize_pipeline_features.json"
   },
   {
     "raster_values_column": "LULC_POLYGON_ID",
-    "raster_feature": ["mask_timeless", "LULC_POLYGON_ERODED_01"],
+    "output_feature": ["mask_timeless", "LULC_POLYGON_ERODED_01"],
     "polygon_buffer": -10,
     "**rasterize_base": "${config_path}/base_rasterize_pipeline_features.json"
   },
   {
     "raster_values_column": "LULC_POLYGON_ID",
-    "raster_feature": ["mask_timeless", "LULC_POLYGON_ERODED_02"],
+    "output_feature": ["mask_timeless", "LULC_POLYGON_ERODED_02"],
     "polygon_buffer": -15,
     "**rasterize_base": "${config_path}/base_rasterize_pipeline_features.json"
   }

--- a/tests/test_config_files/rasterize/rasterize_pipeline_float.json
+++ b/tests/test_config_files/rasterize/rasterize_pipeline_float.json
@@ -1,22 +1,16 @@
-{
-  "pipeline": "eogrow.pipelines.rasterize.RasterizePipeline",
-  "**global_config": "${config_path}/../global_config.json",
-  "input_folder_key": "input_data",
-  "output_folder_key": "temp",
-  "vector_input": "test_area_crops.geojson",
-  "columns": [
-    {
-      "value": 3,
-      "output_feature": ["data_timeless", "INT_FEATURE"],
-      "resolution": 120,
-      "dtype": "uint8"
-    },
-    {
-      "value": 3.5,
-      "output_feature": ["data_timeless", "FLOAT_FEATURE"],
-      "resolution": 10,
-      "dtype": "float32"
-    }
-  ],
-  "preprocess_dataset": {}
-}
+[
+  {
+    "raster_value": 3,
+    "raster_feature": ["data_timeless", "INT_FEATURE"],
+    "resolution": 120,
+    "dtype": "uint8",
+    "**rasterize_base": "${config_path}/base_rasterize_pipeline_float.json"
+  },
+  {
+    "raster_value": 3.5,
+    "raster_feature": ["data_timeless", "FLOAT_FEATURE"],
+    "resolution": 10,
+    "dtype": "float32",
+    "**rasterize_base": "${config_path}/base_rasterize_pipeline_float.json"
+  }
+]

--- a/tests/test_config_files/rasterize/rasterize_pipeline_float.json
+++ b/tests/test_config_files/rasterize/rasterize_pipeline_float.json
@@ -1,14 +1,14 @@
 [
   {
     "raster_value": 3,
-    "raster_feature": ["data_timeless", "INT_FEATURE"],
+    "output_feature": ["data_timeless", "INT_FEATURE"],
     "resolution": 120,
     "dtype": "uint8",
     "**rasterize_base": "${config_path}/base_rasterize_pipeline_float.json"
   },
   {
     "raster_value": 3.5,
-    "raster_feature": ["data_timeless", "FLOAT_FEATURE"],
+    "output_feature": ["data_timeless", "FLOAT_FEATURE"],
     "resolution": 10,
     "dtype": "float32",
     "**rasterize_base": "${config_path}/base_rasterize_pipeline_float.json"

--- a/tests/test_pipelines/test_rasterize.py
+++ b/tests/test_pipelines/test_rasterize.py
@@ -1,5 +1,4 @@
 import os
-from typing import Optional
 
 import geopandas as gpd
 import pytest
@@ -63,15 +62,14 @@ def add_vector_data(pipeline):
         eopatch.save(eopatch_folder, features=[(FeatureType.VECTOR_TIMELESS, "LULC_VECTOR")], overwrite_permission=1)
 
 
-def reset_output_folder(config_path: str) -> Optional[str]:
+def reset_output_folder(config_path: str) -> str:
     raw_config = interpret_config_from_dict(collect_configs_from_path(config_path)[0])
     pipeline = load_pipeline_class(raw_config).from_raw_config(raw_config)
 
-    output_folder_key: Optional[str] = raw_config.get("output_folder_key")
-    if output_folder_key is not None:
-        folder = pipeline.storage.get_folder(output_folder_key)
-        pipeline.storage.filesystem.removetree(folder)
-        return pipeline.storage.get_folder(output_folder_key, full_path=True)
+    output_folder_key: str = raw_config["output_folder_key"]
+    folder = pipeline.storage.get_folder(output_folder_key)
+    pipeline.storage.filesystem.removetree(folder)
+    return pipeline.storage.get_folder(output_folder_key, full_path=True)
 
 
 @pytest.mark.parametrize("experiment_name", ["rasterize_pipeline_float"])


### PR DESCRIPTION
Changes:
- reduce scope of the pipeline to one rasterized output per config
- add validation for vector and raster features
- simplify code according to the changes
- update configs to reflect the changes (split into config chains)
- update tests according to the changes here and in https://github.com/sentinel-hub/eo-grow/pull/210 and https://github.com/sentinel-hub/eo-grow/pull/213