### PR TITLE
A way to reference defaults in logging configs

### DIFF
--- a/eogrow/core/logging.py
+++ b/eogrow/core/logging.py
@@ -49,16 +49,16 @@ class LoggingManager(EOGrowObject):
         eoexecution_ignore_packages: Tuple[str] = Field(
             (DEFAULT_PACKAGES_TOKEN,),
             description=(
-                "Names of packages which logs will not be written to EOExecution log files. You can reference the"
-                'defaults with "...", for example adding another package can be done with ["...", "package_to_ignore"]'
+                "Names of packages for which the logs will not be written to EOExecution log files. You can reference the"
+                'defaults with "...", for example, adding another package can be done with ["...", "package_to_ignore"]'
             ),
         )
 
         pipeline_ignore_packages: Tuple[str] = Field(
             (DEFAULT_PACKAGES_TOKEN,),
             description=(
-                "Names of packages which logs will not be written to the main pipeline log file. You can reference the"
-                'defaults with "...", for example adding another package can be done with ["...", "package_to_ignore"]'
+                "Names of packages for which the logs will not be written to the main pipeline log file. You can reference the"
+                'defaults with "...", for example, adding another package can be done with ["...", "package_to_ignore"]'
             ),
         )
         pipeline_logs_backup_interval: float = Field(
@@ -73,8 +73,8 @@ class LoggingManager(EOGrowObject):
         stdout_log_packages: Tuple[str] = Field(
             (DEFAULT_PACKAGES_TOKEN,),
             description=(
-                'Names of packages which logs will be written to stdout. You can reference the defaults with "...", for'
-                ' example adding another package can be done with ["...", "package_to_display"]'
+                'Names of packages for which the logs will be written to stdout. You can reference the defaults with "...", for'
+                ' example, adding another package can be done with ["...", "package_to_display"]'
             ),
         )
 

--- a/eogrow/core/logging.py
+++ b/eogrow/core/logging.py
@@ -5,7 +5,7 @@ import logging
 import sys
 import time
 from logging import FileHandler, Filter, Formatter, Handler, LogRecord
-from typing import Any, List, Optional, Sequence, Union
+from typing import Any, List, Optional, Sequence, Tuple, Union
 
 import colorlog
 import fs
@@ -24,6 +24,8 @@ from .base import EOGrowObject
 from .config import RawConfig
 from .schemas import ManagerSchema
 from .storage import StorageManager
+
+DEFAULT_PACKAGES_TOKEN = "..."
 
 
 class LoggingManager(EOGrowObject):
@@ -44,18 +46,20 @@ class LoggingManager(EOGrowObject):
                 "with larger number of EOPatches the recommended option is False."
             ),
         )
-        eoexecution_ignore_packages: Optional[List[str]] = Field(
+        eoexecution_ignore_packages: Tuple[str] = Field(
+            (DEFAULT_PACKAGES_TOKEN,),
             description=(
                 "Names of packages which logs will not be written to EOExecution log files. The default null value "
                 "means that a default list of packages will be used."
-            )
+            ),
         )
 
-        pipeline_ignore_packages: Optional[List[str]] = Field(
+        pipeline_ignore_packages: Tuple[str] = Field(
+            (DEFAULT_PACKAGES_TOKEN,),
             description=(
                 "Names of packages which logs will not be written to the main pipeline log file. The default null "
                 "value means that a default list of packages will be used."
-            )
+            ),
         )
         pipeline_logs_backup_interval: float = Field(
             60,
@@ -66,11 +70,12 @@ class LoggingManager(EOGrowObject):
         )
 
         show_logs: bool = Field(False, description="Shows basic pipeline execution logs at stdout.")
-        stdout_log_packages: Optional[List[str]] = Field(
+        stdout_log_packages: Tuple[str] = Field(
+            (DEFAULT_PACKAGES_TOKEN,),
             description=(
                 "Names of packages which logs will be written to stdout. The default null value means that a default "
                 "list of packages will be used."
-            )
+            ),
         )
 
         capture_warnings: bool = Field(
@@ -333,13 +338,13 @@ class StdoutFilter(Filter):
         "sentinelhub.api.batch",
     )
 
-    def __init__(self, *args: Any, log_packages: Optional[Sequence[str]] = None, **kwargs: Any):
+    def __init__(self, *args: Any, log_packages: Sequence[str], **kwargs: Any):
         """
         :param log_packages: Names of packages which logs to include.
         """
         super().__init__(*args, **kwargs)
 
-        self.log_packages = self.DEFAULT_LOG_PACKAGES if log_packages is None else log_packages
+        self.log_packages = _parse_packages(log_packages, self.DEFAULT_LOG_PACKAGES)
 
     def filter(self, record: LogRecord) -> bool:
         """Shows only logs from eo-grow type packages and high-importance logs"""
@@ -361,13 +366,13 @@ class LogFileFilter(Filter):
         "boto3",
     )
 
-    def __init__(self, *args: Any, ignore_packages: Optional[Sequence[str]] = None, **kwargs: Any):
+    def __init__(self, *args: Any, ignore_packages: Sequence[str], **kwargs: Any):
         """
         :param ignore_packages: Names of packages which logs will be ignored.
         """
         super().__init__(*args, **kwargs)
 
-        self.ignore_packages = self.DEFAULT_IGNORE_PACKAGES if ignore_packages is None else tuple(ignore_packages)
+        self.ignore_packages = _parse_packages(ignore_packages, self.DEFAULT_IGNORE_PACKAGES)
 
     def filter(self, record: LogRecord) -> bool:
         """Shows everything from the main thread and process except logs from packages that are on the ignore list.
@@ -393,14 +398,27 @@ class EOExecutionFilter(Filter):
         "fiona._env",
     )
 
-    def __init__(self, ignore_packages: Optional[Sequence[str]] = None, *args: Any, **kwargs: Any):
+    def __init__(self, *args: Any, ignore_packages: Sequence[str], **kwargs: Any):
         """
         :param ignore_packages: Names of packages which logs will be ignored.
         """
         super().__init__(*args, **kwargs)
 
-        self.ignore_packages = self.DEFAULT_IGNORE_PACKAGES if ignore_packages is None else tuple(ignore_packages)
+        self.ignore_packages = _parse_packages(ignore_packages, self.DEFAULT_IGNORE_PACKAGES)
 
     def filter(self, record: LogRecord) -> bool:
         """Ignores logs from certain low-level packages"""
         return not record.name.startswith(self.ignore_packages)
+
+
+def _parse_packages(log_packages: Sequence[str], default_packages: Sequence[str]) -> Tuple[str, ...]:
+    """Builds a tuple of unique package names to be logged/ignored. If the placeholder for default packages is
+    present, those are added as well.
+
+    Since many handlers use the `startswith` method we return a tuple (a better alternative is frozenset).
+    """
+    unique_packages = set(log_packages)
+    if DEFAULT_PACKAGES_TOKEN in unique_packages:
+        unique_packages.remove(DEFAULT_PACKAGES_TOKEN)
+        unique_packages.update(default_packages)
+    return tuple(unique_packages)

--- a/eogrow/core/logging.py
+++ b/eogrow/core/logging.py
@@ -49,16 +49,17 @@ class LoggingManager(EOGrowObject):
         eoexecution_ignore_packages: Tuple[str] = Field(
             (DEFAULT_PACKAGES_TOKEN,),
             description=(
-                "Names of packages for which the logs will not be written to EOExecution log files. You can reference the"
-                'defaults with "...", for example, adding another package can be done with ["...", "package_to_ignore"]'
+                "Names of packages for which the logs will not be written to EOExecution log files. You can reference"
+                ' the defaults with "...", for example, adding another package can be done with ["...", "some_package"]'
             ),
         )
 
         pipeline_ignore_packages: Tuple[str] = Field(
             (DEFAULT_PACKAGES_TOKEN,),
             description=(
-                "Names of packages for which the logs will not be written to the main pipeline log file. You can reference the"
-                'defaults with "...", for example, adding another package can be done with ["...", "package_to_ignore"]'
+                "Names of packages for which the logs will not be written to the main pipeline log file. You can"
+                ' reference the defaults with "...", for example, adding another package can be done with'
+                ' ["...", "some_package"]'
             ),
         )
         pipeline_logs_backup_interval: float = Field(
@@ -73,8 +74,8 @@ class LoggingManager(EOGrowObject):
         stdout_log_packages: Tuple[str] = Field(
             (DEFAULT_PACKAGES_TOKEN,),
             description=(
-                'Names of packages for which the logs will be written to stdout. You can reference the defaults with "...", for'
-                ' example, adding another package can be done with ["...", "package_to_display"]'
+                "Names of packages for which the logs will be written to stdout. You can reference the defaults with"
+                ' "...", for example, adding another package can be done with ["...", "package_to_display"]'
             ),
         )
 

--- a/eogrow/core/logging.py
+++ b/eogrow/core/logging.py
@@ -25,7 +25,7 @@ from .config import RawConfig
 from .schemas import ManagerSchema
 from .storage import StorageManager
 
-DEFAULT_PACKAGES_TOKEN = "..."
+DEFAULT_PACKAGES_TOKEN = "..."  # fix docs if this is changed!
 
 
 class LoggingManager(EOGrowObject):
@@ -49,16 +49,16 @@ class LoggingManager(EOGrowObject):
         eoexecution_ignore_packages: Tuple[str] = Field(
             (DEFAULT_PACKAGES_TOKEN,),
             description=(
-                "Names of packages which logs will not be written to EOExecution log files. The default null value "
-                "means that a default list of packages will be used."
+                "Names of packages which logs will not be written to EOExecution log files. You can reference the"
+                'defaults with "...", for example adding another package can be done with ["...", "package_to_ignore"]'
             ),
         )
 
         pipeline_ignore_packages: Tuple[str] = Field(
             (DEFAULT_PACKAGES_TOKEN,),
             description=(
-                "Names of packages which logs will not be written to the main pipeline log file. The default null "
-                "value means that a default list of packages will be used."
+                "Names of packages which logs will not be written to the main pipeline log file. You can reference the"
+                'defaults with "...", for example adding another package can be done with ["...", "package_to_ignore"]'
             ),
         )
         pipeline_logs_backup_interval: float = Field(
@@ -73,8 +73,8 @@ class LoggingManager(EOGrowObject):
         stdout_log_packages: Tuple[str] = Field(
             (DEFAULT_PACKAGES_TOKEN,),
             description=(
-                "Names of packages which logs will be written to stdout. The default null value means that a default "
-                "list of packages will be used."
+                'Names of packages which logs will be written to stdout. You can reference the defaults with "...", for'
+                ' example adding another package can be done with ["...", "package_to_display"]'
             ),
         )
 

--- a/tests/test_core/test_logging.py
+++ b/tests/test_core/test_logging.py
@@ -60,7 +60,7 @@ def test_logging_with_eoexecutor(fs_loader, logs_handler_factory, workers, multi
             logs_folder="logs-folder",
             filesystem=temp_fs,
             logs_handler_factory=logs_handler_factory,
-            logs_filter=EOExecutionFilter(),
+            logs_filter=EOExecutionFilter(ignore_packages=["..."]),
         )
         executor.run(workers=workers, multiprocess=multiprocess)
         executor.make_report(include_logs=False)


### PR DESCRIPTION
This is mostly relevant for configuring which packages should get through to `stdout`. For example, if you had a new package which relies on `eo-grow`, you had to copy all the defaults and add the name of your package, or your custom pipelines didn't log to stdout. But now you can just set the value to `["...", "mypackage"]`. And if a package is clouding your logs you can do something similar.

It's more of a neat workaround, because I do not feel like overhauling the logging manager ATM