### PR TITLE
Add option for users to specify a custom name for each pipeline

### DIFF
--- a/eogrow/core/pipeline.py
+++ b/eogrow/core/pipeline.py
@@ -58,7 +58,7 @@ class Pipeline(EOGrowObject):
 
     @property
     def _pipeline_name(self) -> str:
-        return self.config.custom_name or self.__class__.__name__
+        return self.config.pipeline_name or self.__class__.__name__
 
     @classmethod
     def from_raw_config(cls: Type[Self], config: RawConfig, *args: Any, **kwargs: Any) -> Self:

--- a/eogrow/core/pipeline.py
+++ b/eogrow/core/pipeline.py
@@ -56,6 +56,10 @@ class Pipeline(EOGrowObject):
         self.area_manager: BaseAreaManager = self._load_manager(config.area, storage=self.storage)
         self.logging_manager: LoggingManager = self._load_manager(config.logging, storage=self.storage)
 
+    @property
+    def _pipeline_name(self) -> str:
+        return self.config.custom_name or self.__class__.__name__
+
     @classmethod
     def from_raw_config(cls: Type[Self], config: RawConfig, *args: Any, **kwargs: Any) -> Self:
         """Creates an object from a dictionary by constructing a validated config and use it to create the object."""
@@ -84,7 +88,7 @@ class Pipeline(EOGrowObject):
 
     def get_pipeline_execution_name(self, pipeline_timestamp: str) -> str:
         """Returns the full name of the pipeline execution"""
-        return f"{pipeline_timestamp}-{self.__class__.__name__}-{self.pipeline_id}"
+        return f"{pipeline_timestamp}-{self._pipeline_name}-{self.pipeline_id}"
 
     def get_patch_list(self) -> PatchList:
         """Method which at the initialization prepares the list of EOPatches which will be used"""
@@ -222,7 +226,7 @@ class Pipeline(EOGrowObject):
                 pipeline_timestamp=timestamp,
             )
 
-            LOGGER.info("Running %s", self.__class__.__name__)
+            LOGGER.info("Running %s", self._pipeline_name)
 
             pipeline_start = time.time()
             finished, failed = self.run_procedure()

--- a/eogrow/core/schemas.py
+++ b/eogrow/core/schemas.py
@@ -27,6 +27,7 @@ class PipelineSchema(BaseSchema):
     """Base schema of the Pipeline class."""
 
     pipeline: Optional[ImportPath] = Field(description="Import path to an implementation of Pipeline class.")
+    custom_name: Optional[str] = Field(description="Custom name for the pipeline for easier identification in logs.")
 
     storage: ManagerSchema = Field(description="A schema of an implementation of StorageManager class")
     validate_storage = field_validator("storage", validate_manager, pre=True)

--- a/eogrow/core/schemas.py
+++ b/eogrow/core/schemas.py
@@ -27,7 +27,9 @@ class PipelineSchema(BaseSchema):
     """Base schema of the Pipeline class."""
 
     pipeline: Optional[ImportPath] = Field(description="Import path to an implementation of Pipeline class.")
-    custom_name: Optional[str] = Field(description="Custom pipeline name for easier identification in logs.")
+    pipeline_name: Optional[str] = Field(
+        description="Custom pipeline name for easier identification in logs. By default the class name is used."
+    )
 
     storage: ManagerSchema = Field(description="A schema of an implementation of StorageManager class")
     validate_storage = field_validator("storage", validate_manager, pre=True)

--- a/eogrow/core/schemas.py
+++ b/eogrow/core/schemas.py
@@ -27,7 +27,7 @@ class PipelineSchema(BaseSchema):
     """Base schema of the Pipeline class."""
 
     pipeline: Optional[ImportPath] = Field(description="Import path to an implementation of Pipeline class.")
-    custom_name: Optional[str] = Field(description="Custom name for the pipeline for easier identification in logs.")
+    custom_name: Optional[str] = Field(description="Custom pipeline name for easier identification in logs.")
 
     storage: ManagerSchema = Field(description="A schema of an implementation of StorageManager class")
     validate_storage = field_validator("storage", validate_manager, pre=True)

--- a/tests/test_config_files/download_and_batch/download_dem.json
+++ b/tests/test_config_files/download_and_batch/download_dem.json
@@ -1,6 +1,6 @@
 {
   "pipeline": "eogrow.pipelines.download.DownloadTimelessPipeline",
-  "custom_name": "DEM_download",
+  "pipeline_name": "DEM_download",
   "**global_config": "${config_path}/../global_config.json",
   "output_folder_key": "temp",
   "data_collection": "DEM",

--- a/tests/test_config_files/download_and_batch/download_dem.json
+++ b/tests/test_config_files/download_and_batch/download_dem.json
@@ -1,5 +1,6 @@
 {
   "pipeline": "eogrow.pipelines.download.DownloadTimelessPipeline",
+  "custom_name": "DEM_download",
   "**global_config": "${config_path}/../global_config.json",
   "output_folder_key": "temp",
   "data_collection": "DEM",

--- a/tests/test_config_files/other/simple_config.json
+++ b/tests/test_config_files/other/simple_config.json
@@ -1,5 +1,6 @@
 {
   "pipeline": "SimplePipeline",
+  "custom_name": "Ladybug47",
   "**global_config": "${config_path}/../global_config.json",
   "test_param": 10,
   "test_subset": [0, "eopatch-id-1-col-0-row-1"],

--- a/tests/test_config_files/other/simple_config.json
+++ b/tests/test_config_files/other/simple_config.json
@@ -1,6 +1,6 @@
 {
   "pipeline": "SimplePipeline",
-  "custom_name": "Ladybug47",
+  "pipeline_name": "Ladybug47",
   "**global_config": "${config_path}/../global_config.json",
   "test_param": 10,
   "test_subset": [0, "eopatch-id-1-col-0-row-1"],


### PR DESCRIPTION
So things i'm not sure about:
- should it be `custom_name`, just `name`, maybe `custom_log_name`?
- do we have this parameter as a regular pipeline parameter, or as part of the `logging` config?