### PR TITLE
Switch to field validators from root validators

### DIFF
--- a/eogrow/pipelines/batch_to_eopatch.py
+++ b/eogrow/pipelines/batch_to_eopatch.py
@@ -2,7 +2,7 @@
 from typing import Any, List, Optional
 
 import numpy as np
-from pydantic import Field, root_validator
+from pydantic import Field, validator
 
 from eolearn.core import (
     CreateEOPatchTask,
@@ -47,10 +47,6 @@ class BatchToEOPatchPipeline(Pipeline):
         input_folder_key: str = Field(description="Storage manager key pointing to the path with Batch results")
         output_folder_key: str = Field(description="Storage manager key pointing to where the EOPatches are saved")
 
-        mapping: List[FeatureMappingSchema] = Field(
-            description="A list of mapping from batch files into EOPatch features."
-        )
-
         userdata_feature_name: Optional[str] = Field(
             description="A name of META_INFO feature in which userdata.json would be stored."
         )
@@ -61,18 +57,23 @@ class BatchToEOPatchPipeline(Pipeline):
             ),
             example="\"[info['date'] for info in json.loads(userdata['metadata'])]\"",
         )
+
+        mapping: List[FeatureMappingSchema] = Field(
+            description="A list of mapping from batch files into EOPatch features."
+        )
+
+        @validator("mapping")
+        def check_something_is_converted(cls, value: list, values: RawSchemaDict) -> list:
+            if not value:
+                params = "userdata_feature_name", "userdata_timestamp_reader"
+                assert any(
+                    values.get(param) is not None for param in params
+                ), "At least one of `userdata_feature_name`, `userdata_timestamp_reader`, or `mapping` has to be set."
+            return value
+
         remove_batch_data: bool = Field(
             True, description="Whether to remove the raw batch data after the conversion is complete"
         )
-
-        @root_validator
-        def check_something_is_converted(cls, values: RawSchemaDict) -> RawSchemaDict:
-            """Check that the pipeline has something to do."""
-            params = "userdata_feature_name", "userdata_timestamp_reader", "mapping"
-            assert any(
-                values.get(param) is not None for param in params
-            ), "At least one of `userdata_feature_name`, `userdata_timestamp_reader`, or `mapping` has to be set."
-            return values
 
     config: Schema
 

--- a/eogrow/pipelines/batch_to_eopatch.py
+++ b/eogrow/pipelines/batch_to_eopatch.py
@@ -63,7 +63,7 @@ class BatchToEOPatchPipeline(Pipeline):
         )
 
         @validator("mapping")
-        def check_something_is_converted(cls, value: list, values: RawSchemaDict) -> list:
+        def check_nonempty_input(cls, value: list, values: RawSchemaDict) -> list:
             if not value:
                 params = "userdata_feature_name", "userdata_timestamp_reader"
                 assert any(

--- a/eogrow/pipelines/prediction.py
+++ b/eogrow/pipelines/prediction.py
@@ -4,15 +4,15 @@ from typing import List, Optional, Tuple
 
 import fs
 import numpy as np
-from pydantic import Field, root_validator
+from pydantic import Field
 
 from eolearn.core import EONode, EOWorkflow, FeatureType, LoadTask, MergeEOPatchesTask, OverwritePermission, SaveTask
 
 from ..core.pipeline import Pipeline
 from ..tasks.prediction import ClassificationPredictionTask, RegressionPredictionTask
-from ..types import Feature, FeatureSpec, PatchList, RawSchemaDict
+from ..types import Feature, FeatureSpec, PatchList
 from ..utils.filter import get_patches_with_missing_features
-from ..utils.validators import optional_field_validator, parse_dtype
+from ..utils.validators import ensure_defined_together, optional_field_validator, parse_dtype
 
 
 class BasePredictionPipeline(Pipeline, metaclass=abc.ABCMeta):
@@ -37,28 +37,16 @@ class BasePredictionPipeline(Pipeline, metaclass=abc.ABCMeta):
         )
         _parse_dtype = optional_field_validator("dtype", parse_dtype, pre=True)
 
-        prediction_mask_folder_key: Optional[str]
         prediction_mask_feature_name: Optional[str] = Field(
             description="Name of `MASK_TIMELESS` feature which defines which areas will be predicted"
         )
+        prediction_mask_folder_key: Optional[str]
+        _ensure_mask_feature_key = ensure_defined_together("prediction_mask_feature_name", "prediction_mask_folder_key")
 
         model_folder_key: str = Field(
             description="The storage manager key pointing to the folder of the model used in the prediction pipeline."
         )
         compress_level: int = Field(1, description="Level of compression used in saving EOPatches")
-
-        @root_validator
-        def validate_prediction_mask(cls, values: RawSchemaDict) -> RawSchemaDict:
-            """If prediction mask is defined then also its input folder has to be defined."""
-            is_mask_defined = values.get("prediction_mask_feature_name") is not None
-            is_folder_defined = values.get("prediction_mask_folder_key") is not None
-
-            if is_mask_defined:
-                assert (
-                    is_folder_defined
-                ), "Parameter prediction_mask_feature_name is defined but prediction_mask_folder_key is not."
-
-            return values
 
     config: Schema
 

--- a/eogrow/pipelines/rasterize.py
+++ b/eogrow/pipelines/rasterize.py
@@ -60,7 +60,7 @@ class RasterizePipeline(Pipeline):
         raster_shape: Optional[Tuple[int, int]] = Field(
             description="Shape of resulting raster image. Cannot be used with `resolution`."
         )
-        _check_shape_resolution = ensure_exactly_one_defined("raster_shape", "resolution")
+        _check_shape_resolution = ensure_exactly_one_defined("resolution", "raster_shape")
 
         dtype: np.dtype = Field(np.dtype("int32"), description="Numpy dtype of the output feature.")
         _parse_dtype = field_validator("dtype", parse_dtype, pre=True)

--- a/eogrow/pipelines/sampling.py
+++ b/eogrow/pipelines/sampling.py
@@ -254,7 +254,7 @@ class BlockSamplingPipeline(BaseRandomSamplingPipeline):
             )
         )
 
-        _check_fraction_number = ensure_exactly_one_defined("fraction_of_samples", "number_of_samples")
+        _check_fraction_number = ensure_exactly_one_defined("number_of_samples", "fraction_of_samples")
 
     config: Schema
 

--- a/eogrow/utils/validators.py
+++ b/eogrow/utils/validators.py
@@ -58,10 +58,10 @@ def ensure_exactly_one_defined(first_param: str, second_param: str, **kwargs: An
     """
 
     def ensure_exclusion(cls: type, value: Optional[Any], values: RawSchemaDict) -> Optional[Any]:
-        is_param1_defined = values.get(first_param) is None
-        is_param2_defined = value is None
+        is_param1_undefined = values.get(first_param) is None
+        is_param2_undefined = value is None
         assert (
-            is_param1_defined != is_param2_defined
+            is_param1_undefined != is_param2_undefined
         ), f"Exactly one of parameters `{first_param}` and `{second_param}` has to be specified."
 
         return value
@@ -78,10 +78,10 @@ def ensure_defined_together(first_param: str, second_param: str, **kwargs: Any) 
     """
 
     def ensure_both(cls: type, value: Optional[Any], values: RawSchemaDict) -> Optional[Any]:
-        is_param1_defined = values.get(first_param) is None
-        is_param2_defined = value is None
+        is_param1_undefined = values.get(first_param) is None
+        is_param2_undefined = value is None
         assert (
-            is_param1_defined == is_param2_defined
+            is_param1_undefined == is_param2_undefined
         ), f"Both or neither of parameters `{first_param}` and `{second_param}` have to be specified."
 
         return value

--- a/eogrow/utils/validators.py
+++ b/eogrow/utils/validators.py
@@ -6,7 +6,7 @@ import inspect
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Optional, Tuple, Type, Union
 
 import numpy as np
-from pydantic import BaseModel, Field, root_validator, validator
+from pydantic import BaseModel, Field, validator
 
 from eolearn.core import FeatureType
 from eolearn.core.utils.parsing import parse_feature
@@ -51,34 +51,44 @@ def optional_field_validator(
     return validator(field, allow_reuse=allow_reuse, **kwargs)(optional_validator)
 
 
-def ensure_exactly_one_defined(param1: str, param2: str, allow_reuse: bool = True, **kwargs: Any) -> classmethod:
-    """A root validator that makes sure only one of the two parameters is defined."""
+def ensure_exactly_one_defined(first_param: str, second_param: str, **kwargs: Any) -> classmethod:
+    """A validator (applied to `second_param` field) that makes sure only one of the two parameters is defined.
 
-    def ensure_exclusion(cls: type, values: RawSchemaDict) -> RawSchemaDict:
-        is_param1_defined = values.get(param1) is None
-        is_param2_defined = values.get(param2) is None
+    Make sure that the definition of `second_param` comes after `first_param˙ (in line-order).
+    """
+
+    def ensure_exclusion(cls: type, value: Optional[Any], values: RawSchemaDict) -> Optional[Any]:
+        is_param1_defined = values.get(first_param) is None
+        is_param2_defined = value is None
         assert (
             is_param1_defined != is_param2_defined
-        ), f"Exactly one of parameters `{param1}` and `{param2}` has to be specified."
+        ), f"Exactly one of parameters `{first_param}` and `{second_param}` has to be specified."
 
-        return values
+        return value
 
-    return root_validator(allow_reuse=allow_reuse, **kwargs)(ensure_exclusion)
+    ensure_exclusion.__name__ = f"cannot_be_used_with_{first_param}"  # used for docbuilding purposes
+
+    return field_validator(second_param, ensure_exclusion, **kwargs)
 
 
-def ensure_defined_together(param1: str, param2: str, allow_reuse: bool = True, **kwargs: Any) -> classmethod:
-    """A root validator that makes sure that the two parameters are both (un)defined."""
+def ensure_defined_together(first_param: str, second_param: str, **kwargs: Any) -> classmethod:
+    """A validator (applied to `second_param` field) that makes sure that the two parameters are both (un)defined.
 
-    def ensure_exclusion(cls: type, values: RawSchemaDict) -> RawSchemaDict:
-        is_param1_defined = values.get(param1) is None
-        is_param2_defined = values.get(param2) is None
+    Make sure that the definition of `second_param` comes after `first_param˙ (in line-order).
+    """
+
+    def ensure_both(cls: type, value: Optional[Any], values: RawSchemaDict) -> Optional[Any]:
+        is_param1_defined = values.get(first_param) is None
+        is_param2_defined = value is None
         assert (
             is_param1_defined == is_param2_defined
-        ), f"Both or neither of parameters `{param1}` and `{param2}` have to be specified."
+        ), f"Both or neither of parameters `{first_param}` and `{second_param}` have to be specified."
 
-        return values
+        return value
 
-    return root_validator(allow_reuse=allow_reuse, **kwargs)(ensure_exclusion)
+    ensure_both.__name__ = f"must_be_used_with_{first_param}"  # used for docbuilding purposes
+
+    return field_validator(second_param, ensure_both, **kwargs)
 
 
 def parse_time_period(value: Tuple[str, str]) -> TimePeriod:


### PR DESCRIPTION
Root validators make sense and are great, BUT they leave the docs messy.
Now the user needs to be careful of the order of parameters, but the docs are much nicer.

Before, each field was marked as having a validator (since there was a root validator)
![image](https://user-images.githubusercontent.com/31988337/232744558-350c749e-85f9-4b66-8462-06dd9c2cb78d.png)

Now only one of the relevant fields is marked. The validator also has a custom name (cause i felt like being extra today).
![image](https://user-images.githubusercontent.com/31988337/232744462-d8cbed25-9d56-47e4-b10f-96d1635040ce.png)
