### PR TITLE
Clean the CLI file

### DIFF
--- a/eogrow/cli.py
+++ b/eogrow/cli.py
@@ -47,14 +47,6 @@ class EOGrowCli:
 
     _command_namespace = "eogrow"
 
-    def __init__(self, command_namespace: Optional[str] = None):
-        """
-        :param command_namespace: A namespace for calling CLI, e.g. command_namespace='eogrow' if you call commands
-            "eogrow config.json".
-        """
-        if command_namespace:
-            EOGrowCli._command_namespace = command_namespace
-
     @staticmethod
     @click.command()
     @click.argument("config_path", type=click.Path())

--- a/eogrow/cli.py
+++ b/eogrow/cli.py
@@ -57,12 +57,10 @@ class EOGrowCli:
 
     @staticmethod
     @click.command()
-    @click.argument("config_filename_or_string", type=click.Path())
+    @click.argument("config_path", type=click.Path())
     @variables_option
     @test_patches_option
-    def main(
-        config_filename_or_string: str, cli_variables: Tuple[str], test_patches: Tuple[int], encoding: bool
-    ) -> None:
+    def main(config_path: str, cli_variables: Tuple[str], test_patches: Tuple[int]) -> None:
         """Execute eo-grow pipeline using CLI.
 
         \b
@@ -70,7 +68,7 @@ class EOGrowCli:
             eogrow config_files/config.json
         """
 
-        raw_configs = collect_configs_from_path(config_filename_or_string)
+        raw_configs = collect_configs_from_path(config_path)
         cli_variable_mapping = dict(_parse_cli_variable(cli_var) for cli_var in cli_variables)
 
         pipelines = []

--- a/eogrow/cli.py
+++ b/eogrow/cli.py
@@ -36,228 +36,216 @@ test_patches_option = click.option(
 )
 
 
-class EOGrowCli:
-    """A command line interface class for `eo-grow`
+@click.command()
+@click.argument("config_path", type=click.Path())
+@variables_option
+@test_patches_option
+def run_pipeline(config_path: str, cli_variables: Tuple[str], test_patches: Tuple[int]) -> None:
+    """Execute eo-grow pipeline using CLI.
 
-    It is designed to be transferable to other packages based on `eo-grow`.
-
-    Note: It looks that click doesn't allow implementing CLI in a proper class structure, therefore here we are using
-    class variable to store the list of packages (https://github.com/pallets/click/issues/601).
+    \b
+    Example:
+        eogrow config_files/config.json
     """
 
-    _command_namespace = "eogrow"
+    raw_configs = collect_configs_from_path(config_path)
+    cli_variable_mapping = dict(_parse_cli_variable(cli_var) for cli_var in cli_variables)
 
-    @staticmethod
-    @click.command()
-    @click.argument("config_path", type=click.Path())
-    @variables_option
-    @test_patches_option
-    def main(config_path: str, cli_variables: Tuple[str], test_patches: Tuple[int]) -> None:
-        """Execute eo-grow pipeline using CLI.
+    pipelines = []
+    for raw_config in raw_configs:
+        config = interpret_config_from_dict(raw_config, cli_variable_mapping)
+        if test_patches:
+            config["test_subset"] = list(test_patches)
 
-        \b
-        Example:
-            eogrow config_files/config.json
-        """
+        pipelines.append(load_pipeline_class(config).from_raw_config(config))
 
-        raw_configs = collect_configs_from_path(config_path)
-        cli_variable_mapping = dict(_parse_cli_variable(cli_var) for cli_var in cli_variables)
+    for pipeline in pipelines:
+        pipeline.run()
 
-        pipelines = []
-        for raw_config in raw_configs:
-            config = interpret_config_from_dict(raw_config, cli_variable_mapping)
-            if test_patches:
-                config["test_subset"] = list(test_patches)
 
-            pipelines.append(load_pipeline_class(config).from_raw_config(config))
+@click.command()
+@click.argument("cluster_yaml", type=click.Path())
+@click.argument("config_path", type=click.Path())
+@click.option(
+    "--start", "start_cluster", is_flag=True, type=bool, help="Starts the cluster if it is not currently running."
+)
+@click.option(
+    "--stop",
+    "stop_cluster",
+    is_flag=True,
+    type=bool,
+    help=(
+        "Stops the cluster if after running the pipeline. In order for this to work got to AWS console "
+        "-> IAM -> Roles -> select ray-autoscaler-v1 role and attach IAMReadOnlyAccess policy."
+    ),
+)
+@click.option(
+    "--screen",
+    "use_screen",
+    is_flag=True,
+    type=bool,
+    help=(
+        "Run the cluster in a detached mode using screen software. Use Ctrl+A+D to detach any time, "
+        "even when running a pipeline or a Jupyter notebook. Use Ctrl+D to terminate the remote screen."
+    ),
+)
+@click.option(
+    "--tmux",
+    "use_tmux",
+    is_flag=True,
+    type=bool,
+    help="Run the cluster in a detached mode using tmux software. Use Ctrl+B and d to detach.",
+)
+@variables_option
+@test_patches_option
+def run_pipeline_on_cluster(
+    config_path: str,
+    cluster_yaml: str,
+    start_cluster: bool,
+    stop_cluster: bool,
+    use_screen: bool,
+    use_tmux: bool,
+    cli_variables: Tuple[str],
+    test_patches: Tuple[int],
+) -> None:
+    """Command for running an eo-grow pipeline on a remote Ray cluster of AWS EC2 instances. The provided config is
+    fully constructed and uploaded to the cluster head in the `~/.synced_configs/` directory, where it is then
+    executed. A custom suffix is added to distinguish runs which use the same config multiple times.
 
-        for pipeline in pipelines:
-            pipeline.run()
+    \b
+    Example:
+        eogrow-ray cluster.yaml config_files/config.json
+    """
+    if start_cluster:
+        start_cluster_if_needed(cluster_yaml)
 
-    @staticmethod
-    @click.command()
-    @click.argument("cluster_yaml", type=click.Path())
-    @click.argument("config_filename", type=click.Path())
-    @click.option(
-        "--start", "start_cluster", is_flag=True, type=bool, help="Starts the cluster if it is not currently running."
+    if stop_cluster and (use_screen or use_tmux):
+        raise NotImplementedError("It is not clear how to combine stop flag with either screen or tmux flag")
+
+    raw_configs = [interpret_config_from_dict(config) for config in collect_configs_from_path(config_path)]
+    remote_path = generate_cluster_config_path(config_path)
+
+    with NamedTemporaryFile(mode="w", delete=True, suffix=".json") as local_path:
+        json.dump(raw_configs, local_path)
+        subprocess.run(f"ray rsync_up {cluster_yaml} {local_path.name!r} {remote_path!r}", shell=True)
+
+    cmd = (
+        f"eogrow {remote_path}"
+        + "".join(f' -v "{cli_var_spec}"' for cli_var_spec in cli_variables)  # noqa B028
+        + "".join(f" -t {patch_index}" for patch_index in test_patches)
+        + ("; " if stop_cluster else "")  # Otherwise, ray will incorrectly prepare a command for stopping a cluster
     )
-    @click.option(
-        "--stop",
-        "stop_cluster",
-        is_flag=True,
-        type=bool,
-        help=(
-            "Stops the cluster if after running the pipeline. In order for this to work got to AWS console "
-            "-> IAM -> Roles -> select ray-autoscaler-v1 role and attach IAMReadOnlyAccess policy."
-        ),
-    )
-    @click.option(
-        "--screen",
-        "use_screen",
-        is_flag=True,
-        type=bool,
-        help=(
-            "Run the cluster in a detached mode using screen software. Use Ctrl+A+D to detach any time, "
-            "even when running a pipeline or a Jupyter notebook. Use Ctrl+D to terminate the remote screen."
-        ),
-    )
-    @click.option(
-        "--tmux",
-        "use_tmux",
-        is_flag=True,
-        type=bool,
-        help="Run the cluster in a detached mode using tmux software. Use Ctrl+B and d to detach.",
-    )
-    @variables_option
-    @test_patches_option
-    def ray(
-        config_filename: str,
-        cluster_yaml: str,
-        start_cluster: bool,
-        stop_cluster: bool,
-        use_screen: bool,
-        use_tmux: bool,
-        cli_variables: Tuple[str],
-        test_patches: Tuple[int],
-    ) -> None:
-        """Command for running an eo-grow pipeline on a remote Ray cluster of AWS EC2 instances. The provided config is
-        fully constructed and uploaded to the cluster head in the `~/.synced_configs/` directory, where it is then
-        executed. A custom suffix is added to distinguish runs which use the same config multiple times.
+    flag_info = [("stop", stop_cluster), ("screen", use_screen), ("tmux", use_tmux)]
+    exec_flags = " ".join(f"--{flag_name}" for flag_name, use_flag in flag_info if use_flag)
 
-        \b
-        Example:
-            eogrow-ray cluster.yaml config_files/config.json
-        """
-        if start_cluster:
-            start_cluster_if_needed(cluster_yaml)
+    subprocess.run(f"ray exec {exec_flags} {cluster_yaml} {cmd!r}", shell=True)  # noqa B028
 
-        if stop_cluster and (use_screen or use_tmux):
-            raise NotImplementedError("It is not clear how to combine stop flag with either screen or tmux flag")
 
-        raw_configs = [interpret_config_from_dict(config) for config in collect_configs_from_path(config_filename)]
-        remote_path = generate_cluster_config_path(config_filename)
+@click.command()
+@click.argument("import_path", type=str)
+@click.argument("template_path", type=click.Path(), required=False)
+@click.option(
+    "-f",
+    "--force",
+    "force_override",
+    is_flag=True,
+    type=bool,
+    help=(
+        "In case a template path is provided and a file in the path already exists this flag is used to force "
+        "override it."
+    ),
+)
+@click.option(
+    "--template-format",
+    "template_format",
+    type=click.Choice(["minimal", "open-api"], case_sensitive=False),
+    help="Specifies which template format to use. The default is `minimal`",
+    default="minimal",
+)
+@click.option(
+    "--required-only",
+    "required_only",
+    is_flag=True,
+    type=bool,
+    help="If provided it will only include required fields in the template. Only for `minimal` template format",
+)
+@click.option(
+    "--add-descriptions",
+    "add_descriptions",
+    is_flag=True,
+    type=bool,
+    help="Adds descriptions to template. Only for `minimal` template format",
+)
+def make_template(
+    import_path: str,
+    template_path: Optional[str],
+    force_override: bool,
+    template_format: str,
+    required_only: bool,
+    add_descriptions: bool,
+) -> None:
+    """Command for creating a config template for an eo-grow pipeline
 
-        with NamedTemporaryFile(mode="w", delete=True, suffix=".json") as local_path:
-            json.dump(raw_configs, local_path)
-            subprocess.run(f"ray rsync_up {cluster_yaml} {local_path.name!r} {remote_path!r}", shell=True)
+    \b
+    Examples:
+        - save template to file:
+            eogrow-template eogrow.pipelines.download.DownloadPipeline config_files/download.json
+        - print template to command line:
+            eogrow-template eogrow.pipelines.download.DownloadPipeline
+    """
+    if not force_override and template_path and os.path.isfile(template_path):
+        raise FileExistsError(f"File {template_path} already exists. You can use -f to force override it.")
 
-        cmd = (
-            f"{EOGrowCli._command_namespace} {remote_path}"
-            + "".join(f' -v "{cli_var_spec}"' for cli_var_spec in cli_variables)  # noqa B028
-            + "".join(f" -t {patch_index}" for patch_index in test_patches)
-            + ("; " if stop_cluster else "")  # Otherwise, ray will incorrectly prepare a command for stopping a cluster
+    class_with_schema = import_object(import_path)
+    schema = collect_schema(class_with_schema)
+
+    if template_format == "open-api":
+        template = schema.schema()
+    else:
+        template = build_schema_template(
+            schema,
+            pipeline_import_path=import_path,
+            required_only=required_only,
+            add_descriptions=add_descriptions,
         )
-        flag_info = [("stop", stop_cluster), ("screen", use_screen), ("tmux", use_tmux)]
-        exec_flags = " ".join(f"--{flag_name}" for flag_name, use_flag in flag_info if use_flag)
 
-        subprocess.run(f"ray exec {exec_flags} {cluster_yaml} {cmd!r}", shell=True)  # noqa B028
+    if template_path:
+        with open(template_path, "w") as file:
+            json.dump(template, file, indent=2, default=jsonify)
+    else:
+        click.echo(json.dumps(template, indent=2, default=jsonify))
 
-    @staticmethod
-    @click.command()
-    @click.argument("import_path", type=str)
-    @click.argument("template_path", type=click.Path(), required=False)
-    @click.option(
-        "-f",
-        "--force",
-        "force_override",
-        is_flag=True,
-        type=bool,
-        help=(
-            "In case a template path is provided and a file in the path already exists this flag is used to force "
-            "override it."
-        ),
-    )
-    @click.option(
-        "--template-format",
-        "template_format",
-        type=click.Choice(["minimal", "open-api"], case_sensitive=False),
-        help="Specifies which template format to use. The default is `minimal`",
-        default="minimal",
-    )
-    @click.option(
-        "--required-only",
-        "required_only",
-        is_flag=True,
-        type=bool,
-        help="If provided it will only include required fields in the template. Only for `minimal` template format",
-    )
-    @click.option(
-        "--add-descriptions",
-        "add_descriptions",
-        is_flag=True,
-        type=bool,
-        help="Adds descriptions to template. Only for `minimal` template format",
-    )
-    def make_template(
-        import_path: str,
-        template_path: Optional[str],
-        force_override: bool,
-        template_format: str,
-        required_only: bool,
-        add_descriptions: bool,
-    ) -> None:
-        """Command for creating a config template for an eo-grow pipeline
 
-        \b
-        Examples:
-            - save template to file:
-                eogrow-template eogrow.pipelines.download.DownloadPipeline config_files/download.json
-            - print template to command line:
-                eogrow-template eogrow.pipelines.download.DownloadPipeline
-        """
-        if not force_override and template_path and os.path.isfile(template_path):
-            raise FileExistsError(f"File {template_path} already exists. You can use -f to force override it.")
+@click.command()
+@click.argument("config_path", type=click.Path())
+def validate_config(config_path: str) -> None:
+    """Validate config without running a pipeline.
 
-        class_with_schema = import_object(import_path)
-        schema = collect_schema(class_with_schema)
+    \b
+    Example:
+        eogrow-validate config_files/config.json
+    """
+    for config in collect_configs_from_path(config_path):
+        raw_config = interpret_config_from_dict(config)
+        load_pipeline_class(config).Schema.parse_obj(raw_config)
 
-        if template_format == "open-api":
-            template = schema.schema()
-        else:
-            template = build_schema_template(
-                schema,
-                pipeline_import_path=import_path,
-                required_only=required_only,
-                add_descriptions=add_descriptions,
-            )
+    click.echo("Config validation succeeded!")
 
-        if template_path:
-            with open(template_path, "w") as file:
-                json.dump(template, file, indent=2, default=jsonify)
-        else:
-            click.echo(json.dumps(template, indent=2, default=jsonify))
 
-    @staticmethod
-    @click.command()
-    @click.argument("config_filename", type=click.Path())
-    def validate_config(config_filename: str) -> None:
-        """Validate config without running a pipeline.
+@click.command()
+@click.argument("config_path", type=click.Path())
+def run_test_pipeline(config_path: str) -> None:
+    """Runs a test pipeline that only makes sure the managers work correctly. This can be used to select best
+    area manager parameters.
 
-        \b
-        Example:
-            eogrow-validate config_files/config.json
-        """
-        for config in collect_configs_from_path(config_filename):
-            raw_config = interpret_config_from_dict(config)
-            load_pipeline_class(config).Schema.parse_obj(raw_config)
-
-        click.echo("Config validation succeeded!")
-
-    @staticmethod
-    @click.command()
-    @click.argument("config_filename", type=click.Path())
-    def run_test_pipeline(config_filename: str) -> None:
-        """Runs a test pipeline that only makes sure the managers work correctly. This can be used to select best
-        area manager parameters.
-
-        \b
-        Example:
-            eogrow-test any_pipeline_config.json
-        """
-        for crude_config in collect_configs_from_path(config_filename):
-            raw_config = interpret_config_from_dict(crude_config)
-            pipeline = TestPipeline.with_defaults(raw_config)
-            pipeline.run()
+    \b
+    Example:
+        eogrow-test any_pipeline_config.json
+    """
+    for crude_config in collect_configs_from_path(config_path):
+        raw_config = interpret_config_from_dict(crude_config)
+        pipeline = TestPipeline.with_defaults(raw_config)
+        pipeline.run()
 
 
 def _parse_cli_variable(mapping_str: str) -> Tuple[str, str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,11 +105,11 @@ Source = "https://github.com/sentinel-hub/eo-grow"
 Forum = "https://forum.sentinel-hub.com"
 
 [project.scripts]
-eogrow = "eogrow.cli:EOGrowCli.main"
-eogrow-ray = "eogrow.cli:EOGrowCli.ray"
-eogrow-template = "eogrow.cli:EOGrowCli.make_template"
-eogrow-validate = "eogrow.cli:EOGrowCli.validate_config"
-eogrow-test = "eogrow.cli:EOGrowCli.run_test_pipeline"
+eogrow = "eogrow.cli:run_pipeline"
+eogrow-ray = "eogrow.cli:run_pipeline_on_cluster"
+eogrow-template = "eogrow.cli:make_template"
+eogrow-validate = "eogrow.cli:validate_config"
+eogrow-test = "eogrow.cli:run_test_pipeline"
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
First thing i noticed is that after we removed the encoding the `eogrow` command was borked, because the variable stayed in the method. So i removed that.

Than i asked myself a simple question. Why in the everloving "#/& is there a class here? So I removed the useless class wrapper.

I also renamed `config_filename` to `config_path` since it fits better.