### PR TITLE
Add common configuration patterns to documentation

### DIFF
--- a/docs/source/common-configuration-patterns.md
+++ b/docs/source/common-configuration-patterns.md
@@ -58,7 +58,7 @@ In some cases, the settings from a global config (or from a different config fil
 }
 ```
 
-The processed configuration will have all the logging settings from `global_config.json`, except for `"capture_warnings"`. See [config language rules](config-language) for config joins.
+The processed configuration will have all the logging settings from `global_config.json`, except for `"capture_warnings"`. See [config language rules](config-language.html) for config joins.
 
 ## Pipeline chains
 

--- a/docs/source/common-configuration-patterns.md
+++ b/docs/source/common-configuration-patterns.md
@@ -7,7 +7,7 @@ Most of the configuration files have a lot in common. This tends to be especiall
 - `storage`
 - `logging`
 
-From our experience it is sometimes easiest to create a so called *global configuration*, which contains all such fields.
+From our experience, it is sometimes easiest to create a so-called *global configuration*, which contains all such fields.
 
 ```
 {  // global_config.json
@@ -36,13 +36,13 @@ This is then used in pipeline configurations.
 }
 ```
 
-This keeps pipeline configs shorter and more readable. One can also use multiple such files, for instance one for each manager. This makes it easy to have pipelines that work on different resolutions, where we just switch between `"**area_config": "${config_path}/area_10m.json"` and `"**area_config": "${config_path}/area_30m.json"`.
+This keeps pipeline configs shorter and more readable. One can also use multiple such files, for instance one for each manager. This makes it easy to have pipelines that work on different resolutions, where it's possible to just switch between `"**area_config": "${config_path}/area_10m.json"` and `"**area_config": "${config_path}/area_30m.json"`.
 
-How fine grained you want to get is usually project-specific. Spreading it too thinly makes it harder to follow what precisely will be in the end config.
+How fine-grained your config structure becomes is usually project-specific. Spreading it too thinly makes it harder to follow what precisely will be in the end config.
 
 ### Adjusting settings from the global config
 
-In some cases the settings from a global config (or from a different config file that you are importing) need to be overridden. Imagine that a pipeline produces a ton of useless warnings, and you only wish to ignore them for that specific pipeline.
+In some cases, the settings from a global config (or from a different config file that you are importing) need to be overridden. Imagine that a pipeline produces a ton of useless warnings, and you only wish to ignore them for that specific pipeline.
 
 ```
 { // export.json
@@ -62,11 +62,11 @@ The processed configuration will have all the logging settings from `global_conf
 
 ## Pipeline chains
 
-Pipeline chains are briefly touched in the config language docs, but only their syntax. Here we'll show two common usage patterns.
+Pipeline chains are briefly touched in the config language docs, but only at the syntax level. Here we'll show two common usage patterns.
 
 ### End-to-end pipeline chain
 
-In certain use-cases we have multiple pipelines, that are meant to be run in a certain succession. A great way of organizing that is via order-prefix naming, so `03_export_pipeline.json` is to be run as the third pipeline.
+In certain use cases we have multiple pipelines that are meant to be run in a certain succession. A great way of organizing that is via order-prefix naming, so `03_export_pipeline.json` is to be run as the third pipeline.
 
 But the user still needs to run them in the correct order and by hand. This we can automate with a simple pipeline chain that links them together:
 ```
@@ -143,7 +143,7 @@ In some cases one wants fine grained control over path specifications. The follo
 }
 ```
 
-We now just need to provide the variables when running the config. This can be done either through the CLI via `eogrow batch_download.json -v "year:2019" -v "quarter:Q1"` or (for increased reproducibility) create configs which just specify the variables:
+We now just need to provide the variables when running the config. This can be done either through the CLI via `eogrow batch_download.json -v "year:2019" -v "quarter:Q1"` or (for increased reproducibility) create configs with the variables specified in advance:
 
 ```
 { // batch_download_2019_Q4.json
@@ -152,9 +152,9 @@ We now just need to provide the variables when running the config. This can be d
 }
 ```
 
-In such cases we advise you do not provide any variables in the core pipeline configuration (i.e. "batch_download.json") so that the config parsing fails if not all variables are specified. Otherwise you risk typo-specific problems such as specifying a value for `"yaer"` which won't override the `"year"` variable (and you download data for 2019 instead of 2020).
+In such cases, we advise you do not provide any variables in the core pipeline configuration (i.e. "batch_download.json") so that the config parsing fails if not all variables are specified. Otherwise you risk typo-specific problems such as specifying a value for `"yaer"` which won't override the `"year"` variable (and you download data for 2019 instead of 2020).
 
-A similar specific-paths mechanism can also be achieved by modifying the storage manager directly:
+A similar specific-paths mechanism can also be achieved by modifying the storage manager directly from the final config:
 ```
 { // batch_download_2019_Q4.json
   "**pipeline": "${config_path}/batch_download.json",
@@ -166,4 +166,4 @@ A similar specific-paths mechanism can also be achieved by modifying the storage
   }
 }
 ```
-While that is sufficient for many cases, in very rich folder structures variables might be less error prone.
+While that is sufficient for many cases and more explicit, variables are preffered and might be less error-prone in case of complex folder structures.

--- a/docs/source/common-configuration-patterns.md
+++ b/docs/source/common-configuration-patterns.md
@@ -1,4 +1,4 @@
-# Common Design Patterns
+# Common Configuration Patterns
 
 ## Global config
 
@@ -167,6 +167,3 @@ A similar specific-paths mechanism can also be achieved by modifying the storage
 }
 ```
 While that is sufficient for many cases, in very rich folder structures variables might be less error prone.
-
-
-## Working in Jupyter

--- a/docs/source/common-configuration-patterns.md
+++ b/docs/source/common-configuration-patterns.md
@@ -58,7 +58,7 @@ In some cases, the settings from a global config (or from a different config fil
 }
 ```
 
-The processed configuration will have all the logging settings from `global_config.json`, except for `"capture_warnings"`. See config language rules for config joins.
+The processed configuration will have all the logging settings from `global_config.json`, except for `"capture_warnings"`. See [config language rules](config-language) for config joins.
 
 ## Pipeline chains
 

--- a/docs/source/common-configuration-patterns.md
+++ b/docs/source/common-configuration-patterns.md
@@ -42,7 +42,7 @@ How fine grained you want to get is usually project-specific. Spreading it too t
 
 ### Adjusting settings from the global config
 
-In some cases the settings from a global config (or from a different config file that you are importing) need to be overriden. Imagine that a pipeline produces a ton of useless warnings, and you only wish to ignore them for that specific pipeline.
+In some cases the settings from a global config (or from a different config file that you are importing) need to be overridden. Imagine that a pipeline produces a ton of useless warnings, and you only wish to ignore them for that specific pipeline.
 
 ```
 { // export.json

--- a/docs/source/common-design-patterns.md
+++ b/docs/source/common-design-patterns.md
@@ -1,4 +1,4 @@
-# Global config
+## Global config
 
 Most of the configuration files have a lot in common. This tends to be especially true for fields describing managers:
 - `area`
@@ -38,7 +38,7 @@ This keeps pipeline configs shorter and more readable. One can also use multiple
 
 How fine grained you want to get is usually project-specific. Spreading it too thinly makes it harder to follow what precisely will be in the end config.
 
-## Adjusting settings from the global config
+### Adjusting settings from the global config
 
 In some cases the settings from a global config (or from a different config file that you are importing) need to be overriden. Imagine that a pipeline produces a ton of useless warnings, and you only wish to ignore them for that specific pipeline.
 
@@ -58,9 +58,9 @@ In some cases the settings from a global config (or from a different config file
 
 The processed configuration will have all the logging settings from `global_config.json`, except for `"capture_warnings"`. See config language rules for config joins.
 
-# Config chains
+## Config chains
 
-# Path modification via variables
+## Path modification via variables
 
 In some cases one wants fine grained control over path specifications. The following is a simplified example of how one can provide separate download paths for a large amount of batch pipelines.
 
@@ -119,4 +119,4 @@ A similar specific-paths mechanism can also be achieved by modifying the storage
 While that is sufficient for many cases, in very rich folder structures variables might be less error prone.
 
 
-# Working in Jupyter
+## Working in Jupyter

--- a/docs/source/common-design-patterns.md
+++ b/docs/source/common-design-patterns.md
@@ -1,3 +1,5 @@
+# Common Design Patterns
+
 ## Global config
 
 Most of the configuration files have a lot in common. This tends to be especially true for fields describing managers:

--- a/docs/source/common-design-patterns.md
+++ b/docs/source/common-design-patterns.md
@@ -1,0 +1,122 @@
+# Global config
+
+Most of the configuration files have a lot in common. This tends to be especially true for fields describing managers:
+- `area`
+- `storage`
+- `logging`
+
+From our experience it is sometimes easiest to create a so called *global configuration*, which contains all such fields.
+
+```
+{  // global_config.json
+  "area": {
+    ...
+  },
+  "storage": {
+    ...
+  },
+  "logging": {
+    ...
+  }
+}
+```
+
+This is then used in pipeline configurations.
+
+```
+{ // export.json
+  "pipeline": "eogrow.pipelines.export_maps.ExportMapsPipeline",
+  "**global_config": "${config_path}/global_config.json",
+  "feature": ["data", "BANDS"],
+  "map_dtype": "int16",
+  "cogify": true,
+  ...
+}
+```
+
+This keeps pipeline configs shorter and more readable. One can also use multiple such files, for instance one for each manager. This makes it easy to have pipelines that work on different resolutions, where we just switch between `"**area_config": "${config_path}/area_10m.json"` and `"**area_config": "${config_path}/area_30m.json"`.
+
+How fine grained you want to get is usually project-specific. Spreading it too thinly makes it harder to follow what precisely will be in the end config.
+
+## Adjusting settings from the global config
+
+In some cases the settings from a global config (or from a different config file that you are importing) need to be overriden. Imagine that a pipeline produces a ton of useless warnings, and you only wish to ignore them for that specific pipeline.
+
+```
+{ // export.json
+  "pipeline": "eogrow.pipelines.export_maps.ExportMapsPipeline",
+  "**global_config": "${config_path}/global_config.json",
+  "logging": {
+    "capture_warnings": false
+  },
+  "feature": ["data", "BANDS"],
+  "map_dtype": "int16",
+  "cogify": true,
+  ...
+}
+```
+
+The processed configuration will have all the logging settings from `global_config.json`, except for `"capture_warnings"`. See config language rules for config joins.
+
+# Config chains
+
+# Path modification via variables
+
+In some cases one wants fine grained control over path specifications. The following is a simplified example of how one can provide separate download paths for a large amount of batch pipelines.
+
+```
+{  // global_config.json
+  "storage": {
+    "structure": {
+      "batch_tiffs": "batch-download/tiffs/year-${var:year}-${var:quarter}",
+      ...
+    },
+    ...
+  },
+  ...
+}
+```
+
+```
+{ // batch_download.json
+  "pipeline": "eogrow.pipelines.download_batch.BatchDownloadPipeline",
+  "**global_config": "${config_path}/global_config.json",
+  "output_folder_key": "batch_tiff",
+  "inputs": [
+    {
+      "data_collection": "SENTINEL2_L2A",
+      "time_period": "${var:year}-${var:quarter}"
+    },
+    ...
+  ],
+  ...
+}
+```
+
+We now just need to provide the variables when running the config. This can be done either through the CLI via `eogrow batch_download.json -v "year:2019" -v "quarter:Q1"` or (for increased reproducibility) create configs which just specify the variables:
+
+```
+{ // batch_download_2019_Q4.json
+  "**pipeline": "${config_path}/batch_download.json",
+  "variables": {"year": 2019, "quarter": "Q4"}
+}
+```
+
+In such cases we advise you do not provide any variables in the core pipeline configuration (i.e. "batch_download.json") so that the config parsing fails if not all variables are specified. Otherwise you risk typo-specific problems such as specifying a value for `"yaer"` which won't override the `"year"` variable (and you download data for 2019 instead of 2020).
+
+A similar specific-paths mechanism can also be achieved by modifying the storage manager directly:
+```
+{ // batch_download_2019_Q4.json
+  "**pipeline": "${config_path}/batch_download.json",
+  "variables": {"year": 2019, "quarter": "Q4"}
+  "storage": {
+    "structure": {
+        "batch_tiffs": "batch-download/tiffs/year-2019-Q4"
+    }
+  }
+}
+```
+While that is sufficient for many cases, in very rich folder structures variables might be less error prone.
+
+
+# Working in Jupyter

--- a/docs/source/common-design-patterns.md
+++ b/docs/source/common-design-patterns.md
@@ -60,7 +60,55 @@ In some cases the settings from a global config (or from a different config file
 
 The processed configuration will have all the logging settings from `global_config.json`, except for `"capture_warnings"`. See config language rules for config joins.
 
-## Config chains
+## Pipeline chains
+
+Pipeline chains are briefly touched in the config language docs, but only their syntax. Here we'll show two common usage patterns.
+
+### End-to-end pipeline chain
+
+In certain use-cases we have multiple pipelines, that are meant to be run in a certain succession. A great way of organizing that is via order-prefix naming, so `03_export_pipeline.json` is to be run as the third pipeline.
+
+But the user still needs to run them in the correct order and by hand. This we can automate with a simple pipeline chain that links them together:
+```
+[ // end_to_end_run.json
+  {"**download": "${config_path}/01_download.json"},
+  {"**preprocess": "${config_path}/02_preprocess_data.json"},
+  {"**predict": "${config_path}/03_use_model.json"},
+  {"**export": "${config_path}/04_export_maps.json"},
+  {"**ingest": "${config_path}/05_ingest_byoc.json"},
+]
+```
+
+A simple `eogrow end_to_end_run.json` now runs all of these pipelines one after another.
+
+### Rerunning with different parameters
+
+In experimentation we often want to run the same pipeline for multiple parameter values. With a tiny bit of boilerplate this can also be taken care of with config chains.
+
+```
+[ // run_threshold_experiments.json
+  {
+    "variables": {"threshold": 0.1},
+    "**pipeline": "${config_path}/extract_trees.json"
+  },
+  {
+    "variables": {"threshold": 0.2},
+    "**pipeline": "${config_path}/extract_trees.json"
+  },
+  {
+    "variables": {"threshold": 0.3},
+    "**pipeline": "${config_path}/extract_trees.json"
+  },
+  {
+    "variables": {"threshold": 0.4},
+    "**pipeline": "${config_path}/extract_trees.json"
+  }
+]
+```
+
+### Using variables with pipelines
+
+While there is no syntactic sugar for specifying pipeline-chain-wide variables in JSON files, one can do that through CLI. Running `eogrow end_to_end_run.json -v "year:2019"` will set the variable `year` to 2019 for all pipelines in the chain.
 
 ## Path modification via variables
 

--- a/docs/source/config-language.md
+++ b/docs/source/config-language.md
@@ -25,7 +25,7 @@ Additional notes:
 - So far, config language is not completely OS-agnostic and it might not support Windows file paths.
 
 
-### Pipeline joins
+### Pipeline chains
 
 A typical configuration is a dictionary with pipeline parameters. However, it can also be a list of dictionaries. In this case each dictionary must contain parameters of a single pipeline. The order of dictionaries defines the consecutive order in which pipelines will be run. Example:
 
@@ -44,3 +44,5 @@ A typical configuration is a dictionary with pipeline parameters. However, it ca
   ...
 ]
 ```
+
+There is currently no functionality to join together two pipeline chains except by copying both explicitly.

--- a/docs/source/config-language.md
+++ b/docs/source/config-language.md
@@ -45,4 +45,4 @@ A typical configuration is a dictionary with pipeline parameters. However, it ca
 ]
 ```
 
-There is currently no functionality to join together two pipeline chains except by copying both explicitly.
+There is currently no functionality to merge multiple pipeline chains, except by manually concatenating their contents into a single file.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,5 +5,5 @@
     :caption: Documentation content:
 
     config-language
-    common-design-patterns
+    common-configuration-patterns
     reference/eogrow

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,4 +5,5 @@
     :caption: Documentation content:
 
     config-language
+    common-design-patterns
     reference/eogrow


### PR DESCRIPTION
I know i made a lot of typos, you know i made a lot of typos.
Let's avoid the back and forth in the review, just push a commit to the appropriate branch. You can voice any other concerns here or ping me directly.

Relevant [docs](https://eo-grow.readthedocs.io/en/add-tips-and-tricks-docs/common-configuration-patterns.html)

We should add tips and tricks for working in Jupyter as well (separate MR to limit the scope).