### PR TITLE
Validate folder key presence in storage structure

### DIFF
--- a/eogrow/utils/validators.py
+++ b/eogrow/utils/validators.py
@@ -94,12 +94,10 @@ def ensure_defined_together(first_param: str, second_param: str, **kwargs: Any) 
 def ensure_storage_key_presence(key: str, **kwargs: Any) -> classmethod:
     """A field validator that makes sure that the specified storage key is present in the storage structure."""
 
-    def validate_storage_key(cls: type, key: str, values: RawSchemaDict) -> str:
-        storage = values.get("storage")
-        assert storage is not None, "Storage schema not found in the config!"
-
-        storage_keys = list(storage.structure.keys()) + ["input_data"]
-        assert key in storage_keys, f"Couldn't find storage key {key!r} in the storage structure!"
+    def validate_storage_key(cls: type, key: Optional[str], values: RawSchemaDict) -> Optional[str]:
+        if key is not None:
+            storage_keys = list(values["storage"].structure.keys()) + ["input_data"]
+            assert key in storage_keys, f"Couldn't find storage key {key!r} in the storage structure!"
         return key
 
     return field_validator(key, validate_storage_key, **kwargs)

--- a/eogrow/utils/validators.py
+++ b/eogrow/utils/validators.py
@@ -91,6 +91,20 @@ def ensure_defined_together(first_param: str, second_param: str, **kwargs: Any) 
     return field_validator(second_param, ensure_both, **kwargs)
 
 
+def ensure_storage_key_presence(key: str, **kwargs: Any) -> classmethod:
+    """A field validator that makes sure that the specified storage key is present in the storage structure."""
+
+    def validate_storage_key(cls: type, key: str, values: RawSchemaDict) -> str:
+        storage = values.get("storage")
+        assert storage is not None, "Storage schema not found in the config!"
+
+        storage_keys = list(storage.structure.keys()) + ["input_data"]
+        assert key in storage_keys, f"Couldn't find storage key {key!r} in the storage structure!"
+        return key
+
+    return field_validator(key, validate_storage_key, **kwargs)
+
+
 def parse_time_period(value: Tuple[str, str]) -> TimePeriod:
     """Allows parsing of preset options of shape `[preset_kind, year]` but that requires `pre` validation"""
     presets = ["yearly", "season", "Q1", "Q2", "Q3", "Q4", "Q1-yearly", "Q2-yearly", "Q3-yearly", "Q4-yearly"]

--- a/eogrow/utils/validators.py
+++ b/eogrow/utils/validators.py
@@ -96,8 +96,11 @@ def ensure_storage_key_presence(key: str, **kwargs: Any) -> classmethod:
 
     def validate_storage_key(cls: type, key: Optional[str], values: RawSchemaDict) -> Optional[str]:
         if key is not None:
-            storage_keys = list(values["storage"].structure.keys()) + ["input_data"]
-            assert key in storage_keys, f"Couldn't find storage key {key!r} in the storage structure!"
+            predefined_keys = ["input_data", "logs", "cache"]
+            assert (
+                key in values["storage"].structure or key in predefined_keys
+            ), f"Couldn't find storage key {key!r} in the storage structure!"
+
         return key
 
     return field_validator(key, validate_storage_key, **kwargs)

--- a/tests/test_utils/test_validators.py
+++ b/tests/test_utils/test_validators.py
@@ -155,6 +155,15 @@ def test_ensure_storage_key_presence(config, folder_key, raises_error):
             DummySchema(folder_key=folder_key, **config)
 
 
+def test_ensure_storage_key_presence_optional_precedence(config):
+    class DummySchema(Pipeline.Schema):
+        folder_key: str
+        _check_folder_key_presence = ensure_storage_key_presence("folder_key")
+
+    with pytest.raises(ValidationError):
+        DummySchema(folder_key=None, **config)
+
+
 @pytest.mark.parametrize(
     "time_period,year,expected_start_date,expected_end_date",
     [

--- a/tests/test_utils/test_validators.py
+++ b/tests/test_utils/test_validators.py
@@ -139,20 +139,19 @@ def test_ensure_defined_together():
         DummySchema2()
 
 
-def test_ensure_storage_key_presence(config):
+@pytest.mark.parametrize(
+    "folder_key,raises_error", [("data", False), ("input_data", False), (None, False), ("i_do_not_exist", True)]
+)
+def test_ensure_storage_key_presence(config, folder_key, raises_error):
     class DummySchema(Pipeline.Schema):
-        folder_key: str
+        folder_key: Optional[str]
         _check_folder_key_presence = ensure_storage_key_presence("folder_key")
 
-    existing_key = list(config["storage"]["structure"].keys())[0]
-    DummySchema(folder_key=existing_key, **config)
-
-    # input_data should always work
-    DummySchema(folder_key="input_data", **config)
-
-    non_existing_key = "i_do_not_exist"
-    with pytest.raises(ValidationError):
-        DummySchema(folder_key=non_existing_key, **config)
+    if not raises_error:
+        DummySchema(folder_key=folder_key, **config)
+    else:
+        with pytest.raises(ValidationError):
+            DummySchema(folder_key=folder_key, **config)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils/test_validators.py
+++ b/tests/test_utils/test_validators.py
@@ -140,13 +140,14 @@ def test_ensure_defined_together():
 
 
 @pytest.mark.parametrize(
-    "folder_key,raises_error", [("data", False), ("input_data", False), (None, False), ("i_do_not_exist", True)]
+    "folder_key,raises_error", [("input_data", False), ("i_exist", False), ("i_do_not_exist", True), (None, False)]
 )
 def test_ensure_storage_key_presence(config, folder_key, raises_error):
     class DummySchema(Pipeline.Schema):
         folder_key: Optional[str]
         _check_folder_key_presence = ensure_storage_key_presence("folder_key")
 
+    config["storage"]["structure"] = {"i_exist": "foobar"}
     if not raises_error:
         DummySchema(folder_key=folder_key, **config)
     else:


### PR DESCRIPTION
Changes:
- added validator for checking folder key presence
- added test

Comments:
- folder keys can be optional (sometimes defaults to "input_data")
- "input_data" key was manually added to be OK (usually not present in the structure, since it's a default)
  - not sure if there is a better way. One could use `PRESET_FOLDERS` from the storage manager, but was afraid of creating circular imports
- storage structure presence is not checked in the validator, since this should already be covered

If this addition makes sense, I can then then open a new MR where this validator is applied where it makes sense