### PR TITLE
Add storage key validators to pipelines

### DIFF
--- a/eogrow/pipelines/batch_to_eopatch.py
+++ b/eogrow/pipelines/batch_to_eopatch.py
@@ -24,7 +24,7 @@ from ..core.schemas import BaseSchema
 from ..tasks.batch_to_eopatch import DeleteFilesTask, FixImportedTimeDependentFeatureTask, LoadUserDataTask
 from ..types import ExecKwargs, Feature, FeatureSpec, PatchList, RawSchemaDict
 from ..utils.filter import get_patches_with_missing_features
-from ..utils.validators import optional_field_validator, parse_dtype
+from ..utils.validators import ensure_storage_key_presence, optional_field_validator, parse_dtype
 
 
 class FeatureMappingSchema(BaseSchema):
@@ -45,7 +45,9 @@ class FeatureMappingSchema(BaseSchema):
 class BatchToEOPatchPipeline(Pipeline):
     class Schema(Pipeline.Schema):
         input_folder_key: str = Field(description="Storage manager key pointing to the path with Batch results")
+        _ensure_input_folder_key = ensure_storage_key_presence("input_folder_key")
         output_folder_key: str = Field(description="Storage manager key pointing to where the EOPatches are saved")
+        _ensure_output_folder_key = ensure_storage_key_presence("output_folder_key")
 
         userdata_feature_name: Optional[str] = Field(
             description="A name of META_INFO feature in which userdata.json would be stored."

--- a/eogrow/pipelines/byoc.py
+++ b/eogrow/pipelines/byoc.py
@@ -21,6 +21,7 @@ from ..types import JsonDict
 from ..utils.validators import (
     ensure_defined_together,
     ensure_exactly_one_defined,
+    ensure_storage_key_presence,
     optional_field_validator,
     parse_data_collection,
 )
@@ -34,6 +35,8 @@ class IngestByocTilesPipeline(Pipeline):
 
     class Schema(Pipeline.Schema):
         byoc_tile_folder_key: str
+        _ensure_byoc_tile_folder_key = ensure_storage_key_presence("byoc_tile_folder_key")
+
         file_glob_pattern: str = Field("**/*.tiff", description="Pattern used to obtain the TIFF files to use")
 
         new_collection_name: Optional[str] = Field(description="Used for defining a new BYOC collection.")
@@ -63,6 +66,8 @@ class IngestByocTilesPipeline(Pipeline):
             raise AssertionError("Sensing time should be set for timeless BYOC collections.")
 
         cover_geometry_folder_key: Optional[str] = Field(description="Folder for supplying a custom cover geometry.")
+        _ensure_cover_geometry_folder_key = ensure_storage_key_presence("cover_geometry_folder_key")
+
         cover_geometry: Optional[str] = Field(description="Specifies a geometry file describing the cover geometry.")
         _ensure_cover_geometry = ensure_defined_together("cover_geometry_folder_key", "cover_geometry")
 

--- a/eogrow/pipelines/download.py
+++ b/eogrow/pipelines/download.py
@@ -30,6 +30,7 @@ from ..types import ExecKwargs, Feature, FeatureSpec, PatchList, ProcessingType,
 from ..utils.filter import get_patches_with_missing_features
 from ..utils.validators import (
     ensure_exactly_one_defined,
+    ensure_storage_key_presence,
     field_validator,
     optional_field_validator,
     parse_data_collection,
@@ -76,6 +77,7 @@ class BaseDownloadPipeline(Pipeline, metaclass=abc.ABCMeta):
         output_folder_key: str = Field(
             description="Storage manager key pointing to the path where downloaded EOPatches will be saved."
         )
+        _ensure_output_folder_key = ensure_storage_key_presence("output_folder_key")
 
         compress_level: int = Field(1, description="Level of compression used in saving EOPatches")
         threads_per_worker: Optional[int] = Field(

--- a/eogrow/pipelines/download_batch.py
+++ b/eogrow/pipelines/download_batch.py
@@ -24,7 +24,13 @@ from ..core.area.batch import BatchAreaManager
 from ..core.pipeline import Pipeline
 from ..core.schemas import BaseSchema
 from ..types import TimePeriod
-from ..utils.validators import field_validator, optional_field_validator, parse_data_collection, parse_time_period
+from ..utils.validators import (
+    ensure_storage_key_presence,
+    field_validator,
+    optional_field_validator,
+    parse_data_collection,
+    parse_time_period,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -65,6 +71,7 @@ class BatchDownloadPipeline(Pipeline):
         output_folder_key: str = Field(
             description="Storage manager key pointing to the path where batch results will be saved."
         )
+        _ensure_output_folder_key = ensure_storage_key_presence("output_folder_key")
 
         inputs: List[InputDataSchema]
         evalscript_path: str

--- a/eogrow/pipelines/export_maps.py
+++ b/eogrow/pipelines/export_maps.py
@@ -28,6 +28,7 @@ from ..core.pipeline import Pipeline
 from ..types import ExecKwargs, Feature, PatchList
 from ..utils.eopatch_list import group_by_crs
 from ..utils.map import CogifyResamplingOptions, WarpResamplingOptions, cogify_inplace, extract_bands, merge_tiffs
+from ..utils.validators import ensure_storage_key_presence
 
 LOGGER = logging.getLogger(__name__)
 
@@ -41,11 +42,13 @@ class ExportMapsPipeline(Pipeline):
         input_folder_key: str = Field(
             description="The storage manager key pointing to the input folder for the export maps pipeline."
         )
+        _ensure_input_folder_key = ensure_storage_key_presence("input_folder_key")
         output_folder_key: str = Field(
             description=(
                 "The storage manager key pointing to the output folder for the maps in the export maps pipeline."
             )
         )
+        _ensure_output_folder_key = ensure_storage_key_presence("output_folder_key")
 
         feature: Feature
         map_name: Optional[str] = Field(regex=r".+\." + MimeType.TIFF.extension + r"?\b")  # noqa

--- a/eogrow/pipelines/features.py
+++ b/eogrow/pipelines/features.py
@@ -29,7 +29,13 @@ from ..tasks.features import (
 )
 from ..types import Feature, FeatureSpec, PatchList, TimePeriod
 from ..utils.filter import get_patches_with_missing_features
-from ..utils.validators import field_validator, optional_field_validator, parse_dtype, parse_time_period
+from ..utils.validators import (
+    ensure_storage_key_presence,
+    field_validator,
+    optional_field_validator,
+    parse_dtype,
+    parse_time_period,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -52,9 +58,11 @@ class FeaturesPipeline(Pipeline):
         input_folder_key: str = Field(
             description="The storage manager key pointing to the input folder for the features pipeline."
         )
+        _ensure_input_folder_key = ensure_storage_key_presence("input_folder_key")
         output_folder_key: str = Field(
             description="The storage manager key pointing to the output folder for the features pipeline."
         )
+        _ensure_output_folder_key = ensure_storage_key_presence("output_folder_key")
 
         bands_feature_name: str = Field(description="Name of data feature containing band data")
 

--- a/eogrow/pipelines/import_tiff.py
+++ b/eogrow/pipelines/import_tiff.py
@@ -14,7 +14,7 @@ from ..core.pipeline import Pipeline
 from ..core.schemas import BaseSchema
 from ..types import Feature, PatchList
 from ..utils.filter import get_patches_with_missing_features
-from ..utils.validators import optional_field_validator, parse_dtype
+from ..utils.validators import ensure_storage_key_presence, optional_field_validator, parse_dtype
 
 
 class ResizeSchema(BaseSchema):
@@ -37,10 +37,13 @@ class ResizeSchema(BaseSchema):
 class ImportTiffPipeline(Pipeline):
     class Schema(Pipeline.Schema):
         output_folder_key: str = Field(description="The storage manager key of the output folder.")
+        _ensure_output_folder_key = ensure_storage_key_presence("output_folder_key")
+
         tiff_folder_key: str = Field(
             "input_data",
             description="The storage manager key of the folder containing the tiff. Defaults to the input-data folder.",
         )
+        _ensure_tiff_folder_key = ensure_storage_key_presence("tiff_folder_key")
         input_filename: str = Field(description="Name of tiff file to import.")
         output_feature: Feature = Field(description="Feature containing the imported tiff information.")
         no_data_value: float = Field(

--- a/eogrow/pipelines/import_vector.py
+++ b/eogrow/pipelines/import_vector.py
@@ -7,12 +7,13 @@ from eolearn.io import VectorImportTask
 
 from ..core.pipeline import Pipeline
 from ..types import ExecKwargs, Feature, PatchList
-from ..utils.validators import field_validator, restrict_types
+from ..utils.validators import ensure_storage_key_presence, field_validator, restrict_types
 
 
 class ImportVectorPipeline(Pipeline):
     class Schema(Pipeline.Schema):
         input_folder_key: str = Field("input_data", description="The folder key into which the EOPatch will be saved. ")
+        _ensure_input_folder_key = ensure_storage_key_presence("input_folder_key")
         input_filename: str = Field(
             description="Filename of the vector file to be imported. Needs to be located in the input-data folder."
         )
@@ -20,6 +21,7 @@ class ImportVectorPipeline(Pipeline):
         clip: bool = Field(True, description="Controls whether the polygons are clipped to the EOPatch boundaries. ")
         output_feature: Feature = Field(description="The EOPatch feature to which the vector will be imported.")
         output_folder_key: str = Field(description="The folder key into which the EOPatch will be saved. ")
+        _ensure_output_folder_key = ensure_storage_key_presence("output_folder_key")
 
         _restrict_output_feature = field_validator(
             "output_feature", restrict_types([FeatureType.VECTOR, FeatureType.VECTOR_TIMELESS])

--- a/eogrow/pipelines/merge_samples.py
+++ b/eogrow/pipelines/merge_samples.py
@@ -11,6 +11,7 @@ from eolearn.core.utils.fs import get_full_path
 
 from ..core.pipeline import Pipeline
 from ..types import Feature, FeatureSpec
+from ..utils.validators import ensure_storage_key_presence
 
 LOGGER = logging.getLogger(__name__)
 
@@ -22,9 +23,12 @@ class MergeSamplesPipeline(Pipeline):
         input_folder_key: str = Field(
             description="The storage manager key pointing to the input folder for the merge samples."
         )
+        _ensure_input_folder_key = ensure_storage_key_presence("input_folder_key")
         output_folder_key: str = Field(
             description="The storage manager key pointing to the output folder for the merge samples pipeline."
         )
+        _ensure_output_folder_key = ensure_storage_key_presence("output_folder_key")
+
         features_to_merge: List[Feature] = Field(
             description="Dictionary of all features for which samples are to be merged."
         )

--- a/eogrow/pipelines/prediction.py
+++ b/eogrow/pipelines/prediction.py
@@ -12,7 +12,12 @@ from ..core.pipeline import Pipeline
 from ..tasks.prediction import ClassificationPredictionTask, RegressionPredictionTask
 from ..types import Feature, FeatureSpec, PatchList
 from ..utils.filter import get_patches_with_missing_features
-from ..utils.validators import ensure_defined_together, optional_field_validator, parse_dtype
+from ..utils.validators import (
+    ensure_defined_together,
+    ensure_storage_key_presence,
+    optional_field_validator,
+    parse_dtype,
+)
 
 
 class BasePredictionPipeline(Pipeline, metaclass=abc.ABCMeta):
@@ -22,6 +27,7 @@ class BasePredictionPipeline(Pipeline, metaclass=abc.ABCMeta):
         input_folder_key: str = Field(
             description="The storage manager key pointing to the input folder of the model input data."
         )
+        _ensure_input_folder_key = ensure_storage_key_presence("input_folder_key")
         input_features: List[Feature] = Field(
             description=(
                 "List of features of form `[(feature_type, feature_name)]` specifying which features are model input in"
@@ -32,6 +38,8 @@ class BasePredictionPipeline(Pipeline, metaclass=abc.ABCMeta):
         output_folder_key: str = Field(
             description="The storage manager key pointing to the output folder for the prediction pipeline."
         )
+        _ensure_output_folder_key = ensure_storage_key_presence("output_folder_key")
+
         dtype: Optional[np.dtype] = Field(
             description="Casts the result to desired type. Uses predictor output type by default."
         )
@@ -46,6 +54,7 @@ class BasePredictionPipeline(Pipeline, metaclass=abc.ABCMeta):
         model_folder_key: str = Field(
             description="The storage manager key pointing to the folder of the model used in the prediction pipeline."
         )
+        _ensure_model_folder_key = ensure_storage_key_presence("model_folder_key")
         compress_level: int = Field(1, description="Level of compression used in saving EOPatches")
 
     config: Schema

--- a/eogrow/pipelines/rasterize.py
+++ b/eogrow/pipelines/rasterize.py
@@ -20,7 +20,7 @@ from ..core.schemas import BaseSchema
 from ..types import Feature, FeatureSpec, PatchList
 from ..utils.filter import get_patches_with_missing_features
 from ..utils.fs import LocalFile
-from ..utils.validators import ensure_exactly_one_defined, field_validator, parse_dtype
+from ..utils.validators import ensure_exactly_one_defined, ensure_storage_key_presence, field_validator, parse_dtype
 from ..utils.vector import concat_gdf
 
 LOGGER = logging.getLogger(__name__)
@@ -40,7 +40,10 @@ class RasterizePipeline(Pipeline):
 
     class Schema(Pipeline.Schema):
         input_folder_key: str = Field(description="The storage manager key pointing to the input folder.")
+        _ensure_input_folder_key = ensure_storage_key_presence("input_folder_key")
         output_folder_key: str = Field(description="The storage manager key pointing to the output folder.")
+        _ensure_output_folder_key = ensure_storage_key_presence("output_folder_key")
+
         vector_input: Union[Feature, str] = Field(description="An input filename or a feature containing vector data.")
         output_feature: Feature = Field(description="A feature which should contain the newly rasterized data.")
 

--- a/eogrow/pipelines/sampling.py
+++ b/eogrow/pipelines/sampling.py
@@ -9,7 +9,7 @@ from eolearn.core import EONode, EOWorkflow, FeatureType, LoadTask, MergeEOPatch
 from eolearn.geometry import MorphologicalOperations, MorphologicalStructFactory
 from eolearn.ml_tools import BlockSamplingTask, FractionSamplingTask, GridSamplingTask
 
-from eogrow.utils.validators import ensure_exactly_one_defined
+from eogrow.utils.validators import ensure_exactly_one_defined, ensure_storage_key_presence
 
 from ..core.pipeline import Pipeline
 from ..tasks.common import ClassFilterTask
@@ -22,6 +22,8 @@ class BaseSamplingPipeline(Pipeline, metaclass=abc.ABCMeta):
 
     class Schema(Pipeline.Schema):
         output_folder_key: str = Field(description="The storage manager key pointing to the pipeline output folder.")
+        _ensure_output_folder_key = ensure_storage_key_presence("output_folder_key")
+
         apply_to: Dict[str, Dict[FeatureType, List[str]]] = Field(
             description=(
                 "A dictionary defining which features to sample, its structure is "

--- a/eogrow/pipelines/split_grid.py
+++ b/eogrow/pipelines/split_grid.py
@@ -20,6 +20,7 @@ from ..tasks.spatial import SpatialSliceTask
 from ..types import ExecKwargs, Feature, FeatureSpec
 from ..utils.fs import LocalFile
 from ..utils.grid import split_bbox
+from ..utils.validators import ensure_storage_key_presence
 
 LOGGER = logging.getLogger(__name__)
 
@@ -37,12 +38,17 @@ class SplitGridPipeline(Pipeline):
         input_folder_key: str = Field(
             description="A storage manager key pointing to the folder where the data will be loaded from."
         )
+        _ensure_input_folder_key = ensure_storage_key_presence("input_folder_key")
         eopatch_output_folder_key: str = Field(
             description="A storage manager key pointing to the folder where the data will be saved."
         )
+        _ensure_eopatch_output_folder_key = ensure_storage_key_presence("eopatch_output_folder_key")
+
         grid_output_folder_key: str = Field(
             description="A storage manager key of where to save the resulting split grid."
         )
+        _ensure_grid_output_folder_key = ensure_storage_key_presence("grid_output_folder_key")
+
         subsplit_grid_filename: str = Field(
             description="Filename of new grid, which can be used in `CustomAreaManager`.", regex=r"^.+\.gpkg$"
         )

--- a/eogrow/pipelines/testing.py
+++ b/eogrow/pipelines/testing.py
@@ -12,7 +12,7 @@ from ..core.pipeline import Pipeline
 from ..core.schemas import BaseSchema
 from ..tasks.testing import DummyRasterFeatureTask, DummyTimestampFeatureTask
 from ..types import ExecKwargs, Feature, PatchList, TimePeriod
-from ..utils.validators import field_validator, parse_dtype, parse_time_period
+from ..utils.validators import ensure_storage_key_presence, field_validator, parse_dtype, parse_time_period
 
 Self = TypeVar("Self", bound="TestPipeline")
 LOGGER = logging.getLogger(__name__)
@@ -86,6 +86,8 @@ class DummyDataPipeline(Pipeline):
 
     class Schema(Pipeline.Schema):
         output_folder_key: str = Field(description="The storage manager key pointing to the pipeline output folder.")
+        _ensure_output_folder_key = ensure_storage_key_presence("output_folder_key")
+
         seed: Optional[int] = Field(description="A randomness seed.")
 
         raster_features: List[RasterFeatureSchema] = Field(

--- a/eogrow/pipelines/training.py
+++ b/eogrow/pipelines/training.py
@@ -23,6 +23,7 @@ from sklearn.preprocessing import LabelEncoder
 
 from ..core.pipeline import Pipeline
 from ..core.schemas import BaseSchema
+from ..utils.validators import ensure_storage_key_presence
 
 LOGGER = logging.getLogger(__name__)
 
@@ -45,9 +46,11 @@ class BaseTrainingPipeline(Pipeline, metaclass=abc.ABCMeta):
 
     class Schema(Pipeline.Schema):
         input_folder_key: str = Field(description="The storage manager key pointing to the model training data.")
+        _ensure_input_folder_key = ensure_storage_key_presence("input_folder_key")
         model_folder_key: str = Field(
             description="The storage manager key pointing to the folder where the model will be saved."
         )
+        _ensure_model_folder_key = ensure_storage_key_presence("model_folder_key")
 
         train_features: List[str] = Field(
             description="A list of feature filenames to join into training features in the given order."

--- a/eogrow/pipelines/zipmap.py
+++ b/eogrow/pipelines/zipmap.py
@@ -26,7 +26,7 @@ LOGGER = logging.getLogger(__name__)
 
 class InputFeatureSchema(BaseSchema):
     feature: Feature = Field(description="Which features to load from folder.")
-    folder_key: str = Field("The storage manager key pointing to the folder from which to load data.")
+    folder_key: str = Field(description="The storage manager key pointing to the folder from which to load data.")
     include_bbox_and_timestamp = Field(
         True,
         description="Auto loads BBOX and (if the features is temporal) TIMESTAMP.",


### PR DESCRIPTION
Sadly cant be used in nested schemas or in area managers at the moment