### PR TITLE
Fix missing py.typed in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,11 @@ build-backend = 'hatchling.build'
 [tool.hatch.version]
 path = 'eogrow/__init__.py'
 
-[tool.hatch.build]
-exclude = ["/docs", "/tests"]
-
 [tool.hatch.build.targets.sdist]
 include = ['/README.md', '/LICENSE.md', '/eogrow']
+
+[tool.hatch.build.targets.wheel]
+include = ['/eogrow']
 
 [project]
 name = "eo-grow"


### PR DESCRIPTION
Had trouble with building a wheel since the start. This time we're not excluding docs and tests, but specifying what to include. This seems to get the results we want.