### PR TITLE
Remove redundant isort def

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,20 +116,6 @@ eogrow-test = "eogrow.cli:run_test_pipeline"
 line-length = 120
 preview = true
 
-[tool.isort]
-profile = "black"
-known_first_party = ["sentinelhub", "eolearn"]
-known_absolute = "eogrow"
-sections = [
-    "FUTURE",
-    "STDLIB",
-    "THIRDPARTY",
-    "FIRSTPARTY",
-    "ABSOLUTE",
-    "LOCALFOLDER",
-]
-line_length = 120
-
 [tool.ruff]
 line-length = 120
 target-version = "py38"


### PR DESCRIPTION
No longer required after using ruff for sorting imports