### PR TITLE
Store cluster.yaml in logs

### DIFF
--- a/eogrow/cli.py
+++ b/eogrow/cli.py
@@ -9,6 +9,7 @@ from typing import Optional, Tuple
 import click
 
 from .core.config import collect_configs_from_path, interpret_config_from_dict
+from .core.logging import CLUSTER_FILE_LOCATION
 from .core.schemas import build_schema_template
 from .pipelines.testing import TestPipeline
 from .utils.general import jsonify
@@ -105,7 +106,7 @@ def run_pipeline_on_cluster(
         local_path.flush()  # without this the sync can happen before the file content is written
 
         subprocess.run(f"ray rsync_up {cluster_yaml} {local_path.name!r} {remote_path!r}", shell=True)
-        subprocess.run(f"ray rsync_up {cluster_yaml} {cluster_yaml!r} {cluster_yaml!r}", shell=True)
+        subprocess.run(f"ray rsync_up {cluster_yaml} {cluster_yaml!r} {CLUSTER_FILE_LOCATION!r}", shell=True)
 
     cmd = (
         f"eogrow {remote_path}"

--- a/eogrow/cli.py
+++ b/eogrow/cli.py
@@ -9,7 +9,7 @@ from typing import Optional, Tuple
 import click
 
 from .core.config import collect_configs_from_path, interpret_config_from_dict
-from .core.logging import CLUSTER_FILE_LOCATION
+from .core.logging import CLUSTER_FILE_LOCATION_ON_HEAD
 from .core.schemas import build_schema_template
 from .pipelines.testing import TestPipeline
 from .utils.general import jsonify
@@ -106,7 +106,7 @@ def run_pipeline_on_cluster(
         local_path.flush()  # without this the sync can happen before the file content is written
 
         subprocess.run(f"ray rsync_up {cluster_yaml} {local_path.name!r} {remote_path!r}", shell=True)
-        subprocess.run(f"ray rsync_up {cluster_yaml} {cluster_yaml!r} {CLUSTER_FILE_LOCATION!r}", shell=True)
+        subprocess.run(f"ray rsync_up {cluster_yaml} {cluster_yaml!r} {CLUSTER_FILE_LOCATION_ON_HEAD!r}", shell=True)
 
     cmd = (
         f"eogrow {remote_path}"

--- a/eogrow/cli.py
+++ b/eogrow/cli.py
@@ -105,6 +105,7 @@ def run_pipeline_on_cluster(
         local_path.flush()  # without this the sync can happen before the file content is written
 
         subprocess.run(f"ray rsync_up {cluster_yaml} {local_path.name!r} {remote_path!r}", shell=True)
+        subprocess.run(f"ray rsync_up {cluster_yaml} {cluster_yaml!r} {cluster_yaml!r}", shell=True)
 
     cmd = (
         f"eogrow {remote_path}"

--- a/eogrow/core/logging.py
+++ b/eogrow/core/logging.py
@@ -152,7 +152,6 @@ class LoggingManager(EOGrowObject):
         """If it detects a synced `cluster.yaml` file, it will copy it to the logs folder."""
         os_folder, os_file = fs.path.split(CLUSTER_FILE_LOCATION)
         os_fs = OSFS(os_folder)
-        assert os_fs.exists(os_file)
         if os_fs.exists(os_file):
             fs.copy.copy_file(os_fs, os_file, self.storage.filesystem, fs.path.join(logs_folder, "cluster.yaml"))
 

--- a/eogrow/core/logging.py
+++ b/eogrow/core/logging.py
@@ -2,7 +2,6 @@
 import contextlib
 import json
 import logging
-import os
 import sys
 import time
 from logging import FileHandler, Filter, Formatter, Handler, LogRecord
@@ -151,11 +150,11 @@ class LoggingManager(EOGrowObject):
 
     def _add_cluster_config_to_logs(self, logs_folder: str) -> None:
         """If it detects a synced `cluster.yaml` file, it will copy it to the logs folder."""
-        if os.path.exists(CLUSTER_FILE_LOCATION):
-            os_folder, os_file = fs.path.split(CLUSTER_FILE_LOCATION)
-            fs.copy.copy_file(
-                OSFS(os_folder), os_file, self.storage.filesystem, fs.path.join(logs_folder, "cluster.yaml")
-            )
+        os_folder, os_file = fs.path.split(CLUSTER_FILE_LOCATION)
+        os_fs = OSFS(os_folder)
+        assert os_fs.exists(os_file)
+        if os_fs.exists(os_file):
+            fs.copy.copy_file(os_fs, os_file, self.storage.filesystem, fs.path.join(logs_folder, "cluster.yaml"))
 
     def _create_file_handler(self, pipeline_execution_name: str) -> Handler:
         """Creates a logging handler to write a pipeline log to a file."""

--- a/eogrow/core/logging.py
+++ b/eogrow/core/logging.py
@@ -148,8 +148,11 @@ class LoggingManager(EOGrowObject):
 
     def _add_cluster_config_to_logs(self, logs_folder: str) -> None:
         """If it detects a synced `cluster.yaml` file, it will copy it to the logs folder."""
+        global_logger = logging.getLogger()
         filesystem = self.storage.filesystem
+        global_logger.info("Trying to copy to %s", logs_folder)
         if filesystem.exists(CLUSTER_FILE_LOCATION):
+            global_logger.info("Executing copy", logs_folder)
             filesystem.copy(CLUSTER_FILE_LOCATION, fs.path.join(logs_folder, "cluster.yaml"))
 
     def _create_file_handler(self, pipeline_execution_name: str) -> Handler:

--- a/eogrow/core/logging.py
+++ b/eogrow/core/logging.py
@@ -2,6 +2,7 @@
 import contextlib
 import json
 import logging
+import os
 import sys
 import time
 from logging import FileHandler, Filter, Formatter, Handler, LogRecord
@@ -150,9 +151,9 @@ class LoggingManager(EOGrowObject):
 
     def _add_cluster_config_to_logs(self, logs_folder: str) -> None:
         """If it detects a synced `cluster.yaml` file, it will copy it to the logs folder."""
-        os_folder, os_file = fs.path.split(CLUSTER_FILE_LOCATION_ON_HEAD)
-        os_fs = OSFS(os_folder)  # the file is on the head node, might not be visible in storage.filesystem
-        if os_fs.exists(os_file):
+        if os.path.exists(CLUSTER_FILE_LOCATION_ON_HEAD):
+            os_folder, os_file = fs.path.split(CLUSTER_FILE_LOCATION_ON_HEAD)
+            os_fs = OSFS(os_folder)  # the file is on the head node, might not be visible in storage.filesystem
             fs.copy.copy_file(os_fs, os_file, self.storage.filesystem, fs.path.join(logs_folder, "cluster.yaml"))
 
     def _create_file_handler(self, pipeline_execution_name: str) -> Handler:

--- a/eogrow/core/logging.py
+++ b/eogrow/core/logging.py
@@ -29,7 +29,7 @@ from .schemas import ManagerSchema
 from .storage import StorageManager
 
 DEFAULT_PACKAGES_TOKEN = "..."  # fix docs if this is changed!
-CLUSTER_FILE_LOCATION = fs.path.join(CLUSTER_CONFIG_DIR, "cluster.yaml")
+CLUSTER_FILE_LOCATION_ON_HEAD = fs.path.join(CLUSTER_CONFIG_DIR, "cluster.yaml")
 
 
 class LoggingManager(EOGrowObject):
@@ -150,8 +150,8 @@ class LoggingManager(EOGrowObject):
 
     def _add_cluster_config_to_logs(self, logs_folder: str) -> None:
         """If it detects a synced `cluster.yaml` file, it will copy it to the logs folder."""
-        os_folder, os_file = fs.path.split(CLUSTER_FILE_LOCATION)
-        os_fs = OSFS(os_folder)
+        os_folder, os_file = fs.path.split(CLUSTER_FILE_LOCATION_ON_HEAD)
+        os_fs = OSFS(os_folder)  # the file is on the head node, might not be visible in storage.filesystem
         if os_fs.exists(os_file):
             fs.copy.copy_file(os_fs, os_file, self.storage.filesystem, fs.path.join(logs_folder, "cluster.yaml"))
 

--- a/eogrow/core/logging.py
+++ b/eogrow/core/logging.py
@@ -151,7 +151,8 @@ class LoggingManager(EOGrowObject):
 
     def _add_cluster_config_to_logs(self, logs_folder: str) -> None:
         """If it detects a synced `cluster.yaml` file, it will copy it to the logs folder."""
-        if os.path.exists(CLUSTER_FILE_LOCATION_ON_HEAD):
+        os_path = CLUSTER_FILE_LOCATION_ON_HEAD.replace("~", os.path.expanduser("~"))
+        if os.path.exists(os_path):
             os_folder, os_file = fs.path.split(CLUSTER_FILE_LOCATION_ON_HEAD)
             os_fs = OSFS(os_folder)  # the file is on the head node, might not be visible in storage.filesystem
             fs.copy.copy_file(os_fs, os_file, self.storage.filesystem, fs.path.join(logs_folder, "cluster.yaml"))


### PR DESCRIPTION
We decided for a simple procedure:

1. `eogrow-ray` transfers `cluster.yaml` onto the head instance (similar to configs). This does not need to be named in a 'execution-specific-way' because if you switch to a different cluster configuration you'll (almost surely) also switch the head node
2. Each pipeline checks if there is a `cluster.yaml` in the expected location, if there is, it copies it over.

Tested it out on a simple case to make sure it works