### PR TITLE
Add a flag to use zarr arrays

### DIFF
--- a/eogrow/core/storage.py
+++ b/eogrow/core/storage.py
@@ -41,6 +41,7 @@ class StorageManager(EOGrowObject):
         geopandas_backend: Literal["fiona", "pyogrio"] = Field(
             "fiona", description="Which backend is used for IO operations when using geopandas."
         )
+        save_with_zarr: bool = Field(False, description="Whether to save EOPatches with the Zarr backend.")
 
         class Config(ManagerSchema.Config):
             case_sensitive = True

--- a/eogrow/core/storage.py
+++ b/eogrow/core/storage.py
@@ -41,7 +41,7 @@ class StorageManager(EOGrowObject):
         geopandas_backend: Literal["fiona", "pyogrio"] = Field(
             "fiona", description="Which backend is used for IO operations when using geopandas."
         )
-        save_with_zarr: bool = Field(False, description="Whether to save EOPatches with the Zarr backend.")
+        use_zarr: bool = Field(False, description="Whether to use the Zarr backend for EOPatch IO.")
 
         class Config(ManagerSchema.Config):
             case_sensitive = True

--- a/eogrow/pipelines/download.py
+++ b/eogrow/pipelines/download.py
@@ -152,6 +152,7 @@ class BaseDownloadPipeline(Pipeline, metaclass=abc.ABCMeta):
                 filesystem=self.storage.filesystem,
                 features=self._get_output_features(),
                 overwrite_permission=OverwritePermission.OVERWRITE_FEATURES,
+                use_zarr=self.storage.config.save_with_zarr,
             ),
             inputs=[postprocessing_node or download_node],
         )

--- a/eogrow/pipelines/download.py
+++ b/eogrow/pipelines/download.py
@@ -152,7 +152,7 @@ class BaseDownloadPipeline(Pipeline, metaclass=abc.ABCMeta):
                 filesystem=self.storage.filesystem,
                 features=self._get_output_features(),
                 overwrite_permission=OverwritePermission.OVERWRITE_FEATURES,
-                use_zarr=self.storage.config.save_with_zarr,
+                use_zarr=self.storage.config.use_zarr,
             ),
             inputs=[postprocessing_node or download_node],
         )

--- a/eogrow/pipelines/features.py
+++ b/eogrow/pipelines/features.py
@@ -124,7 +124,7 @@ class FeaturesPipeline(Pipeline):
             filesystem=self.storage.filesystem,
             features=self._get_output_features(),
             overwrite_permission=OverwritePermission.OVERWRITE_FEATURES,
-            use_zarr=self.storage.config.save_with_zarr,
+            use_zarr=self.storage.config.use_zarr,
         )
         save_node = EONode(save_task, inputs=[postprocessing_node])
 

--- a/eogrow/pipelines/features.py
+++ b/eogrow/pipelines/features.py
@@ -124,6 +124,7 @@ class FeaturesPipeline(Pipeline):
             filesystem=self.storage.filesystem,
             features=self._get_output_features(),
             overwrite_permission=OverwritePermission.OVERWRITE_FEATURES,
+            use_zarr=self.storage.config.save_with_zarr,
         )
         save_node = EONode(save_task, inputs=[postprocessing_node])
 

--- a/eogrow/pipelines/import_tiff.py
+++ b/eogrow/pipelines/import_tiff.py
@@ -110,6 +110,7 @@ class ImportTiffPipeline(Pipeline):
             overwrite_permission=OverwritePermission.OVERWRITE_FEATURES,
             config=self.sh_config,
             features=[self.config.output_feature],
+            use_zarr=self.storage.config.save_with_zarr,
         )
         save_node = EONode(save_task, inputs=[resize_node or import_node])
 

--- a/eogrow/pipelines/import_tiff.py
+++ b/eogrow/pipelines/import_tiff.py
@@ -110,7 +110,7 @@ class ImportTiffPipeline(Pipeline):
             overwrite_permission=OverwritePermission.OVERWRITE_FEATURES,
             config=self.sh_config,
             features=[self.config.output_feature],
-            use_zarr=self.storage.config.save_with_zarr,
+            use_zarr=self.storage.config.use_zarr,
         )
         save_node = EONode(save_task, inputs=[resize_node or import_node])
 

--- a/eogrow/pipelines/import_vector.py
+++ b/eogrow/pipelines/import_vector.py
@@ -58,6 +58,7 @@ class ImportVectorPipeline(Pipeline):
             filesystem=self.storage.filesystem,
             features=[self.config.output_feature],
             overwrite_permission=OverwritePermission.OVERWRITE_FEATURES,
+            use_zarr=self.storage.config.save_with_zarr,
         )
         save_node = EONode(save_task, inputs=[import_node])
         return EOWorkflow.from_endnodes(save_node)

--- a/eogrow/pipelines/import_vector.py
+++ b/eogrow/pipelines/import_vector.py
@@ -58,7 +58,7 @@ class ImportVectorPipeline(Pipeline):
             filesystem=self.storage.filesystem,
             features=[self.config.output_feature],
             overwrite_permission=OverwritePermission.OVERWRITE_FEATURES,
-            use_zarr=self.storage.config.save_with_zarr,
+            use_zarr=self.storage.config.use_zarr,
         )
         save_node = EONode(save_task, inputs=[import_node])
         return EOWorkflow.from_endnodes(save_node)

--- a/eogrow/pipelines/prediction.py
+++ b/eogrow/pipelines/prediction.py
@@ -125,6 +125,7 @@ class BasePredictionPipeline(Pipeline, metaclass=abc.ABCMeta):
             filesystem=self.storage.filesystem,
             features=self._get_output_features(),
             overwrite_permission=OverwritePermission.OVERWRITE_FEATURES,
+            use_zarr=self.storage.config.save_with_zarr,
         )
 
         return EONode(save_task, inputs=[previous_node])

--- a/eogrow/pipelines/prediction.py
+++ b/eogrow/pipelines/prediction.py
@@ -125,7 +125,7 @@ class BasePredictionPipeline(Pipeline, metaclass=abc.ABCMeta):
             filesystem=self.storage.filesystem,
             features=self._get_output_features(),
             overwrite_permission=OverwritePermission.OVERWRITE_FEATURES,
-            use_zarr=self.storage.config.save_with_zarr,
+            use_zarr=self.storage.config.use_zarr,
         )
 
         return EONode(save_task, inputs=[previous_node])

--- a/eogrow/pipelines/rasterize.py
+++ b/eogrow/pipelines/rasterize.py
@@ -191,7 +191,7 @@ class RasterizePipeline(Pipeline):
             filesystem=self.storage.filesystem,
             features=self._get_output_features(),
             overwrite_permission=OverwritePermission.OVERWRITE_FEATURES,
-            use_zarr=self.storage.config.save_with_zarr,
+            use_zarr=self.storage.config.use_zarr,
         )
         save_node = EONode(save_task, inputs=[postprocess_node])
 

--- a/eogrow/pipelines/rasterize.py
+++ b/eogrow/pipelines/rasterize.py
@@ -191,6 +191,7 @@ class RasterizePipeline(Pipeline):
             filesystem=self.storage.filesystem,
             features=self._get_output_features(),
             overwrite_permission=OverwritePermission.OVERWRITE_FEATURES,
+            use_zarr=self.storage.config.save_with_zarr,
         )
         save_node = EONode(save_task, inputs=[postprocess_node])
 

--- a/eogrow/pipelines/sampling.py
+++ b/eogrow/pipelines/sampling.py
@@ -75,7 +75,7 @@ class BaseSamplingPipeline(Pipeline, metaclass=abc.ABCMeta):
             filesystem=self.storage.filesystem,
             features=self._get_output_features(),
             overwrite_permission=OverwritePermission.OVERWRITE_FEATURES,
-            use_zarr=self.storage.config.save_with_zarr,
+            use_zarr=self.storage.config.use_zarr,
         )
 
         return EOWorkflow.from_endnodes(EONode(save_task, inputs=[sampling_node]))

--- a/eogrow/pipelines/sampling.py
+++ b/eogrow/pipelines/sampling.py
@@ -75,6 +75,7 @@ class BaseSamplingPipeline(Pipeline, metaclass=abc.ABCMeta):
             filesystem=self.storage.filesystem,
             features=self._get_output_features(),
             overwrite_permission=OverwritePermission.OVERWRITE_FEATURES,
+            use_zarr=self.storage.config.save_with_zarr,
         )
 
         return EOWorkflow.from_endnodes(EONode(save_task, inputs=[sampling_node]))

--- a/eogrow/pipelines/split_grid.py
+++ b/eogrow/pipelines/split_grid.py
@@ -157,6 +157,7 @@ class SplitGridPipeline(Pipeline):
                 filesystem=self.storage.filesystem,
                 features=self.config.features,
                 overwrite_permission=OverwritePermission.OVERWRITE_FEATURES,
+                use_zarr=self.storage.config.save_with_zarr,
             )
             save_node = EONode(save_task, inputs=[slice_node])
             processing_nodes.append(save_node)

--- a/eogrow/pipelines/split_grid.py
+++ b/eogrow/pipelines/split_grid.py
@@ -157,7 +157,7 @@ class SplitGridPipeline(Pipeline):
                 filesystem=self.storage.filesystem,
                 features=self.config.features,
                 overwrite_permission=OverwritePermission.OVERWRITE_FEATURES,
-                use_zarr=self.storage.config.save_with_zarr,
+                use_zarr=self.storage.config.use_zarr,
             )
             save_node = EONode(save_task, inputs=[slice_node])
             processing_nodes.append(save_node)

--- a/eogrow/pipelines/testing.py
+++ b/eogrow/pipelines/testing.py
@@ -137,7 +137,7 @@ class GenerateDataPipeline(Pipeline):
             filesystem=self.storage.filesystem,
             overwrite_permission=OverwritePermission.OVERWRITE_FEATURES,
             save_timestamps=self.config.timestamps is not None,
-            use_zarr=self.storage.config.save_with_zarr,
+            use_zarr=self.storage.config.use_zarr,
         )
         save_node = EONode(save_task, inputs=[previous_node])
 

--- a/eogrow/pipelines/testing.py
+++ b/eogrow/pipelines/testing.py
@@ -137,6 +137,7 @@ class GenerateDataPipeline(Pipeline):
             filesystem=self.storage.filesystem,
             overwrite_permission=OverwritePermission.OVERWRITE_FEATURES,
             save_timestamps=self.config.timestamps is not None,
+            use_zarr=self.storage.config.save_with_zarr,
         )
         save_node = EONode(save_task, inputs=[previous_node])
 

--- a/eogrow/pipelines/zipmap.py
+++ b/eogrow/pipelines/zipmap.py
@@ -114,7 +114,7 @@ class ZipMapPipeline(Pipeline):
             config=self.sh_config,
             features=[self.config.output_feature],
             overwrite_permission=OverwritePermission.OVERWRITE_FEATURES,
-            use_zarr=self.storage.config.save_with_zarr,
+            use_zarr=self.storage.config.use_zarr,
         )
         save_node = EONode(save_task, inputs=[mapping_node])
 

--- a/eogrow/pipelines/zipmap.py
+++ b/eogrow/pipelines/zipmap.py
@@ -114,6 +114,7 @@ class ZipMapPipeline(Pipeline):
             config=self.sh_config,
             features=[self.config.output_feature],
             overwrite_permission=OverwritePermission.OVERWRITE_FEATURES,
+            use_zarr=self.storage.config.save_with_zarr,
         )
         save_node = EONode(save_task, inputs=[mapping_node])
 


### PR DESCRIPTION
I am unsure about the parameter name. I was also considering the `use_zarr` flag, but i'm worried that this flag would be used in some pipelines to also use zarr optimizations.

Open to suggestions.

The tests do not include this, since Zarr is not a requirement of eo-grow. I turned this flag on in the global config and the whole thing worked automagically.