### PR TITLE
Make patch_list generating faster

### DIFF
--- a/eogrow/core/area/base.py
+++ b/eogrow/core/area/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABCMeta, abstractmethod
+from functools import partial
 from typing import Literal, Optional
 
 import fiona
@@ -131,10 +132,10 @@ class BaseAreaManager(EOGrowObject, metaclass=ABCMeta):
     def get_patch_list(self) -> PatchList:
         """Returns a list of eopatch names and appropriate BBoxes."""
 
-        named_bboxes = []
+        named_bboxes: PatchList = []
         for crs, grid in self.get_grid(filtered=True).items():
-            for _, row in grid.iterrows():
-                named_bboxes.append((row.eopatch_name, BBox(row.geometry.bounds, crs=crs)))
+            bounds = grid.geometry.bounds.apply(tuple, axis=1)
+            named_bboxes.extend(zip(grid[self.NAME_COLUMN], bounds.map(partial(BBox, crs=crs))))
 
         return named_bboxes
 


### PR DESCRIPTION
This took a bit of experimenting but the end result is that in a grid of 2 x 100 000 patches, the time to generate the patch list goes from 18s to 1.75s :smile_cat: 

The idea was to stay in geopandas as long as possible. Some other things I tried:
- Mapping directly on `grid.geometry` kinda works, but since `BBox` is not a valid geometry, an error gets raised (and silenced), but in the process of raising this error a deprecation warning for the BBox string representation pops up :see_no_evil:. I mean we could silence that, but it also only gets us to 2.7s
- Then i tried applying a helper function directly onto the `grid.bounds`. This got me to 2.1s, but the code was long and the helper function couldn't be a lambda (does not capture the crs), so it was an additional definition which had to be wrapped by `partial` etc. So it was actually more code than the current solution.
- Tried to preprocess as much as possible (get stuff to a series of tuples) in a pandas-compatible way. I then remembered that `partial` also works on classes. So this was clean and fast :smile_cat: 

I did some minor tests and I don't think we can get it to work much faster. Extracting the boundary tuples from the grid takes a bit under 1s, and just creating 200 000 bboxes takes a bit under 1s. So this seems to be about as good as we can get without a brand new idea.