### PR TITLE
Enable Github actions to trigger internal Gitlab CI

### DIFF
--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -113,19 +113,3 @@ jobs:
           files: coverage.xml
           fail_ci_if_error: true
           verbose: false
-
-  mirror-to-gitlab:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Mirror + trigger CI
-        uses: SvanBoxel/gitlab-mirror-and-ci-action@master
-        with:
-          args: "https://git.sinergise.com/eo/code/eo-grow"
-        env:
-          GITLAB_HOSTNAME: "git.sinergise.com"
-          GITLAB_USERNAME: "github-action"
-          GITLAB_PASSWORD: ${{ secrets.GITLAB_PASSWORD }}
-          GITLAB_PROJECT_ID: "878"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_trigger.yml
+++ b/.github/workflows/ci_trigger.yml
@@ -13,7 +13,6 @@ on:
 
 jobs:
   mirror-to-gitlab:
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci_trigger.yml
+++ b/.github/workflows/ci_trigger.yml
@@ -1,0 +1,30 @@
+name: mirror_and_trigger
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "master"
+      - "develop"
+  workflow_call:
+  release:
+    types:
+      - published
+
+jobs:
+  mirror-to-gitlab:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Mirror + trigger CI
+        uses: SvanBoxel/gitlab-mirror-and-ci-action@master
+        with:
+          args: "https://git.sinergise.com/eo/code/eo-grow"
+        env:
+          FOLLOW_TAGS: "true"
+          GITLAB_HOSTNAME: "git.sinergise.com"
+          GITLAB_USERNAME: "github-action"
+          GITLAB_PASSWORD: ${{ secrets.GITLAB_PASSWORD }}
+          GITLAB_PROJECT_ID: "878"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,18 @@
+image: python:3.9
+
+stages:
+  - build
+
+build_docker_image:
+  stage: build
+  needs: []
+  rules:
+    - if: $CI_COMMIT_TAG # run only on releases
+      when: always
+      variables:
+        CUSTOM_RUN_TAG: auto # this will create images with the latest tag and the version tag
+        LAYER_NAME: dotai-eo
+    - when: manual
+  trigger:
+    project: teams/eor/dotai/infra
+  allow_failure: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,5 +14,5 @@ build_docker_image:
         LAYER_NAME: dotai-eo
     - when: manual
   trigger:
-    project: teams/eor/dotai/infra
+    project: eo/infra/docker
   allow_failure: true


### PR DESCRIPTION
Changes:
- mirror tags as well
- trigger on releases also (should trigger internal docker build)