### PR TITLE
Run pipeline on remote

### DIFF
--- a/eogrow/cli.py
+++ b/eogrow/cli.py
@@ -85,6 +85,7 @@ def run_pipeline(
         if config.get("debug", False):
             load_pipeline_class(config).from_raw_config(config).run()
         else:
+            ray.init(address="auto", ignore_reinit_error=True)
             ray.get(_pipeline_spawner.options(**ray_kwargs).remote(config))  # type: ignore[attr-defined]
 
 

--- a/eogrow/cli.py
+++ b/eogrow/cli.py
@@ -104,6 +104,7 @@ def _pipeline_spawner(config: dict) -> None:
 )
 @variables_option
 @test_patches_option
+@ray_remote_kwargs_option
 def run_pipeline_on_cluster(
     config_path: str,
     cluster_yaml: str,
@@ -111,6 +112,7 @@ def run_pipeline_on_cluster(
     use_tmux: bool,
     cli_variables: Tuple[str, ...],
     test_patches: Tuple[int, ...],
+    ray_remote_kwargs_option: str,
 ) -> None:
     """Command for running an eo-grow pipeline on a remote Ray cluster of AWS EC2 instances. The provided config is
     fully constructed and uploaded to the cluster head in the `~/.synced_configs/` directory, where it is then
@@ -137,6 +139,7 @@ def run_pipeline_on_cluster(
         f"eogrow {remote_path}"
         + "".join(f' -v "{cli_var_spec}"' for cli_var_spec in cli_variables)  # B028
         + "".join(f" -t {patch_index}" for patch_index in test_patches)
+        + f" --ray_remote_kwargs {ray_remote_kwargs_option!r}"
     )
     exec_flags = "--tmux" if use_tmux else ""
 

--- a/eogrow/cli.py
+++ b/eogrow/cli.py
@@ -1,5 +1,6 @@
 """Implements the command line interface for `eo-grow`."""
 
+import ast
 import json
 import os
 import re
@@ -66,7 +67,7 @@ def run_pipeline(
 
     raw_configs = collect_configs_from_path(config_path)
     cli_variable_mapping = dict(_parse_cli_variable(cli_var) for cli_var in cli_variables)
-    ray_kwargs = json.loads(ray_remote_kwargs)
+    ray_kwargs = ast.literal_eval(ray_remote_kwargs)
 
     configs = []
     for raw_config in raw_configs:
@@ -112,7 +113,7 @@ def run_pipeline_on_cluster(
     use_tmux: bool,
     cli_variables: Tuple[str, ...],
     test_patches: Tuple[int, ...],
-    ray_remote_kwargs_option: str,
+    ray_remote_kwargs: str,
 ) -> None:
     """Command for running an eo-grow pipeline on a remote Ray cluster of AWS EC2 instances. The provided config is
     fully constructed and uploaded to the cluster head in the `~/.synced_configs/` directory, where it is then
@@ -139,7 +140,7 @@ def run_pipeline_on_cluster(
         f"eogrow {remote_path}"
         + "".join(f' -v "{cli_var_spec}"' for cli_var_spec in cli_variables)  # B028
         + "".join(f" -t {patch_index}" for patch_index in test_patches)
-        + f" --ray_remote_kwargs {ray_remote_kwargs_option!r}"
+        + rf' --ray_remote_kwargs "{ray_remote_kwargs}"'
     )
     exec_flags = "--tmux" if use_tmux else ""
 


### PR DESCRIPTION
When using CLI commands the pipeline initialization is done on a worker process.

The process can request ray remote resources via (multiple) `-r` options, e.g. `-r "num_cpus:3" -r "resources.my_resource:1"`.
With this the main pipeline process can be requested to run on a worker machine.

If `debug: True` is detected in a pipeline config the process will not be started in a worker process (making it easier to use `ipdb`).

~Currently using `eogrow config.json` will spawn a local cluster if it does not exist yet. This might be a win for researchers, but after some testing i got 72 idle ray processes so I'm inclined to put brakes on that.~
The cluster has to be started manually even when running locally. I get lots of zombie processes if i let python do it.

Any names are up to debate, I think there is a lot of repetition between these and the pipeline parameters.

The one downside i see is that all stdout logs now have a worker-process prefix (file logs are fine). Maybe we could/should get rid of that? takes up valuable screen space.

