### PR TITLE
Fix pipeline-chain validation

### DIFF
--- a/eogrow/cli.py
+++ b/eogrow/cli.py
@@ -207,7 +207,11 @@ def validate_config(config_path: str) -> None:
         pipeline_config = _prepare_config(config, {}, ())
         collect_schema(load_pipeline_class(pipeline_config)).parse_obj(pipeline_config)
     else:
-        validate_pipeline_chain([_prepare_config(run_config, {}, ()) for run_config in config])
+        for i, run_config in enumerate(config):
+            if "pipeline_config" not in run_config:
+                raise ValueError(f"Pipeline-chain element {i} is missing the field `pipeline_config`.")
+            run_config["pipeline_config"] = _prepare_config(run_config["pipeline_config"], {}, ())
+        validate_pipeline_chain(config)
 
     click.echo("Config validation succeeded!")
 

--- a/eogrow/cli.py
+++ b/eogrow/cli.py
@@ -211,7 +211,7 @@ def validate_config(config_path: str) -> None:
             if "pipeline_config" not in run_config:
                 raise ValueError(f"Pipeline-chain element {i} is missing the field `pipeline_config`.")
             run_config["pipeline_config"] = _prepare_config(run_config["pipeline_config"], {}, ())
-        validate_pipeline_chain(config)
+        validate_pipeline_chain(config)  # type: ignore[arg-type]
 
     click.echo("Config validation succeeded!")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,11 @@ def test_help(command):
     assert subprocess.call(f"{command} --help", shell=True) == 0
 
 
+def test_pipeline_chain_validation(config_folder):
+    """Tests a simple execution from command line"""
+    assert subprocess.call(f"eogrow-validate {config_folder}/chain_pipeline_to_validate.json", shell=True) == 0
+
+
 @pytest.mark.parametrize(
     "command_params",
     [

--- a/tests/test_config_files/chain_pipeline_to_validate.json
+++ b/tests/test_config_files/chain_pipeline_to_validate.json
@@ -1,0 +1,15 @@
+[
+  // this is not meant to be run, just validated
+  { "pipeline_config": { "**pipeline": "${config_path}/zipmap/zipmap.json" } },
+  {
+    "pipeline_config": {
+      "**pipeline": "${config_path}/import_tiff/import_tiff_timeless.json",
+      "variables": { "no_data": 0 },
+      "no_data_value": "${var:no_data}"
+    }
+  },
+  {
+    "pipeline_config": { "**pipeline": "${config_path}/zipmap/zipmap.json" },
+    "pipeline_resources": { "memory": 1e9 }
+  }
+]


### PR DESCRIPTION
As per usual, one finds the bug just after release :upside_down_face: 

The problem is that variables are handled with `interpret_config_from_dict` which pops them directly from the config. In this case the config is `{"pipeline_config": ...}` and thus does not have variables (which are one level lower). The interpretation then fails because it finds variables that it does not have defined (because it didnt manage to pop the correct variable dict). Tried to get around that.

Do you think this is important enough to release 1.7.1 tomorrow?