### PR TITLE
Remove aws profile parameter from storage manager schema

### DIFF
--- a/eogrow/core/storage.py
+++ b/eogrow/core/storage.py
@@ -60,8 +60,9 @@ class StorageManager(EOGrowObject):
         will show a warning and return a config without AWS credentials."""
         sh_config = SHConfig()
 
-        if self.is_on_s3() and os.getenv("AWS_PROFILE"):
-            sh_config = get_aws_credentials(aws_profile=os.getenv("AWS_PROFILE"), config=sh_config)
+        aws_profile = os.getenv("AWS_PROFILE")
+        if self.is_on_s3() and aws_profile is not None:
+            sh_config = get_aws_credentials(aws_profile=aws_profile, config=sh_config)
 
         return sh_config
 

--- a/eogrow/core/storage.py
+++ b/eogrow/core/storage.py
@@ -60,8 +60,8 @@ class StorageManager(EOGrowObject):
         will show a warning and return a config without AWS credentials."""
         sh_config = SHConfig()
 
-        if self.is_on_s3() and os.environ["AWS_PROFILE"]:
-            sh_config = get_aws_credentials(aws_profile=os.environ["AWS_PROFILE"], config=sh_config)
+        if self.is_on_s3() and os.getenv("AWS_PROFILE"):
+            sh_config = get_aws_credentials(aws_profile=os.getenv("AWS_PROFILE"), config=sh_config)
 
         return sh_config
 

--- a/eogrow/core/storage.py
+++ b/eogrow/core/storage.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, Dict, Literal, Optional
+import os
+from typing import Any, ClassVar, Dict, Literal
 
 import fs
 from pydantic import BaseSettings, Field
@@ -22,13 +23,6 @@ class StorageManager(EOGrowObject):
             description=(
                 "The root project folder. Can be either local or on AWS S3 Bucket."
                 "If on AWS, the path must be prefixed with s3://."
-            ),
-        )
-        aws_profile: Optional[str] = Field(
-            env="AWS_PROFILE",
-            description=(
-                "The AWS profile with credentials needed to access the S3 buckets. In case the profile isn't specified"
-                " with a parameter it can be read from an environmental variable."
             ),
         )
         filesystem_kwargs: Dict[str, Any] = Field(
@@ -66,8 +60,8 @@ class StorageManager(EOGrowObject):
         will show a warning and return a config without AWS credentials."""
         sh_config = SHConfig()
 
-        if self.is_on_s3() and self.config.aws_profile:
-            sh_config = get_aws_credentials(aws_profile=self.config.aws_profile, config=sh_config)
+        if self.is_on_s3() and os.environ["AWS_PROFILE"]:
+            sh_config = get_aws_credentials(aws_profile=os.environ["AWS_PROFILE"], config=sh_config)
 
         return sh_config
 

--- a/tests/core/test_storage.py
+++ b/tests/core/test_storage.py
@@ -1,8 +1,6 @@
 import os
-from typing import Optional
 
 import pytest
-from botocore.exceptions import ProfileNotFound
 from fs.osfs import OSFS
 from fs_s3fs import S3FS
 
@@ -65,41 +63,6 @@ def test_get_custom_folder(local_storage_manager: StorageManager, project_folder
 
     abs_path = os.path.join(project_folder, "path", "to", "eopatches")
     assert local_storage_manager.get_folder("eopatches", full_path=True) == abs_path
-
-
-@pytest.mark.parametrize("config_profile", [None, "", "nonexistent-config-profile"])
-@pytest.mark.parametrize("env_profile", [None, "", "nonexistent-env-profile"])
-def test_aws_profile(aws_storage_config: RawConfig, config_profile: Optional[str], env_profile: Optional[str]):
-    """Checks different combinations of profile being set with a config parameter and environmental variable. Checks
-    also that config parameter takes priority over environmental variable.
-
-    In the first step of this test, we add given profile name parameters into the config dictionary and into the
-    dictionary of environmental variables. Note that if profile name is `None`, we instead remove the parameter from a
-    dictionary altogether.
-    """
-
-    for parameter_key, parameter_value, config_dict in [
-        ("aws_profile", config_profile, aws_storage_config),
-        ("AWS_PROFILE", env_profile, os.environ),
-    ]:
-        if parameter_value is not None:
-            config_dict[parameter_key] = parameter_value
-        elif parameter_key in config_dict:
-            del config_dict[parameter_key]
-
-    try:
-        expected_profile = config_profile if config_profile is not None else env_profile
-        if expected_profile:
-            with pytest.raises(ProfileNotFound) as exception_info:
-                StorageManager.from_raw_config(aws_storage_config)
-
-            assert str(exception_info.value) == f"The config profile ({expected_profile}) could not be found"
-        else:
-            storage = StorageManager.from_raw_config(aws_storage_config)
-            assert storage.config.aws_profile == expected_profile
-    finally:
-        if "AWS_PROFILE" in os.environ:
-            del os.environ["AWS_PROFILE"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config_files/other/aws_storage_test.json
+++ b/tests/test_config_files/other/aws_storage_test.json
@@ -1,7 +1,6 @@
 {
   "manager": "eogrow.core.storage.StorageManager",
   "project_folder": "s3://eogrow-test-storage/test",
-  "aws_profile": null,
   "structure": {
     "batch": "tiffs",
     "eopatches": "eopatches"


### PR DESCRIPTION
As discussed internally, this option is now removed in favor of always taking the value from the `AWS_PROFILE` environment variable.