### PR TITLE
Fail stats comparison if changes are present also when updating the stats

### DIFF
--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -90,10 +90,8 @@ jobs:
           pip install -e .[DEV,ML]
           pip install gdal==$(gdal-config --version)
 
-      - name: Set up local cluster # we need to install async-timeout until ray 2.9.0 fixes the issue
-        run: |
-          pip install async-timeout
-          ray start --head
+      - name: Set up local cluster
+        run: ray start --head
 
       - name: Run fast tests
         if: ${{ !matrix.full_test_suite }}

--- a/eogrow/utils/testing.py
+++ b/eogrow/utils/testing.py
@@ -368,11 +368,11 @@ def compare_content(
         raise ValueError("The given path is None. The pipeline likely has no `output_folder_key` parameter.")
     config = StatCalcConfig() if config is None else config
     stats = calculate_statistics(folder_path, config=config)
+    stats_difference = compare_with_saved(stats, stats_path)
 
     if save_new_stats:
         save_statistics(stats, stats_path)
 
-    stats_difference = compare_with_saved(stats, stats_path)
     if stats_difference:
         stats_difference_repr = stats_difference.to_json(indent=2, sort_keys=True)
         raise AssertionError(f"Expected and obtained stats differ:\n{stats_difference_repr}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,15 +41,16 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Image Processing",
 ]
 dependencies = [
+    'aiohttp_cors<0.8; python_version == "3.8"',
+    "boto3<=1.29.6",
     "click",
     "colorlog",
-    "boto3<=1.29.6",
     "eo-learn[VISUALIZATION]>=1.5.0",
-    "fiona>=1.8.18; python_version>='3.9'",
     "fiona>=1.8.18,<1.10; python_version<'3.9'",
+    "fiona>=1.8.18; python_version>='3.9'",
     "fs>=2.2.0",
-    "geopandas>=0.14.4,<1; python_version>='3.9'",
     "geopandas>=0.11.0,<1; python_version<'3.9'",
+    "geopandas>=0.14.4,<1; python_version>='3.9'",
     "numpy",
     "opencv-python-headless",
     "pandas",
@@ -68,7 +69,7 @@ ml = ["joblib", "lightgbm>=3.0.0", "scikit-learn"]
 docs = [
     "autodoc_pydantic",
     "nbsphinx",
-    "sphinx_mdinclude==0.5.4",  #0.6 didn't work last time
+    "sphinx_mdinclude==0.5.4", #0.6 didn't work last time
     "sphinx-rtd-theme==1.3.0",
     "sphinx==7.1.2",
 ]


### PR DESCRIPTION
In the `compare_content` we have the option to set the `save_new_stats` parameter to true, which will save the new statistics. The new statistics will then be compared and the comparison should find no difference, which is the only possible conclusion, since the comparison in this case is basically the identity check and brings no value.

It makes more sense to fail the test regardless of the `save_new_stats` parameter:
- such a behavior is more in line with pre-commit/lint checks, where fixes are applied, but the job fails if changes were made
- jobs can be run only once and you can then make use of the test as well as the stats update using artifacts