### PR TITLE
Add batch grid creation functions

### DIFF
--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -90,10 +90,8 @@ jobs:
           pip install -e .[DEV,ML]
           pip install gdal==$(gdal-config --version)
 
-      - name: Set up local cluster # we need to install async-timeout until ray 2.9.0 fixes the issue
-        run: |
-          pip install async-timeout
-          ray start --head
+      - name: Set up local cluster
+        run: ray start --head
 
       - name: Run fast tests
         if: ${{ !matrix.full_test_suite }}

--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Mirror + trigger CI
         uses: SvanBoxel/gitlab-mirror-and-ci-action@master
         with:
-          args: "https://hello.planet.com/code/eo/code/eo-grow"
+          args: "https://hello.planet.com/code/solution-enablement/eo/code/eo-grow"
         env:
           FOLLOW_TAGS: "true"
           GITLAB_HOSTNAME: "hello.planet.com/code"

--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -60,9 +60,9 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
           - "3.10"
           - "3.11"
+          - "3.12"
         include:
           # A flag marks whether full or partial tests should be run
           # We don't run integration tests on pull requests from outside repos, because they don't have secrets

--- a/eogrow/core/area/utm.py
+++ b/eogrow/core/area/utm.py
@@ -96,11 +96,10 @@ def create_utm_zone_grid(
     for i, (bbox, info) in enumerate(zip(bbox_list, info_list)):
         i_x, i_y = info["index_x"], info["index_y"]
         name = f"eopatch-id-{i:0{zfill_length}}-col-{i_x}-row-{i_y}"
-        crs_to_patches[bbox.crs].append((name, bbox.geometry))
+        crs_to_patches[bbox.crs].append({"id": i, name_column: name, "geometry": bbox.geometry})
 
     grid = {}
     for crs, named_bbox_geoms in crs_to_patches.items():
-        names, geoms = zip(*named_bbox_geoms)
-        grid[crs] = gpd.GeoDataFrame({name_column: names}, geometry=list(geoms), crs=crs.pyproj_crs())
+        grid[crs] = gpd.GeoDataFrame(named_bbox_geoms, geometry="geometry", crs=crs.pyproj_crs())
 
     return grid

--- a/eogrow/core/area/utm.py
+++ b/eogrow/core/area/utm.py
@@ -51,32 +51,14 @@ class UtmZoneAreaManager(BaseAreaManager):
         """Uses UtmZoneSplitter to create a grid"""
         area_geometry = self.get_area_geometry()
         LOGGER.info("Splitting area geometry into UTM zone grid")
-        splitter = UtmZoneSplitter(
-            [area_geometry.geometry],
-            crs=area_geometry.crs,
-            bbox_size=(self.config.patch.size_x, self.config.patch.size_y),
-            offset=(self.config.offset_x, self.config.offset_y),
+
+        return create_utm_zone_grid(
+            area_geometry,
+            self.NAME_COLUMN,
+            (self.config.patch.size_x, self.config.patch.size_y),
+            (self.config.offset_x, self.config.offset_y),
+            (self.config.patch.buffer_x, self.config.patch.buffer_y),
         )
-
-        bbox_list, info_list = splitter.get_bbox_list(), splitter.get_info_list()
-
-        absolute_buffer = self.config.patch.buffer_x, self.config.patch.buffer_y
-        if absolute_buffer != (0, 0):
-            bbox_list = [bbox.buffer(absolute_buffer, relative=False) for bbox in bbox_list]
-
-        crs_to_patches = defaultdict(list)
-        zfill_length = len(str(len(bbox_list) - 1))
-        for i, (bbox, info) in enumerate(zip(bbox_list, info_list)):
-            i_x, i_y = info["index_x"], info["index_y"]
-            name = f"eopatch-id-{i:0{zfill_length}}-col-{i_x}-row-{i_y}"
-            crs_to_patches[bbox.crs].append((name, bbox.geometry))
-
-        grid = {}
-        for crs, named_bbox_geoms in crs_to_patches.items():
-            names, geoms = zip(*named_bbox_geoms)
-            grid[crs] = gpd.GeoDataFrame({self.NAME_COLUMN: names}, geometry=list(geoms), crs=crs.pyproj_crs())
-
-        return grid
 
     def get_grid_cache_filename(self) -> str:
         input_filename = fs.path.basename(self.config.geometry_filename)
@@ -94,3 +76,31 @@ class UtmZoneAreaManager(BaseAreaManager):
         params = [str(param) for param in raw_params]
 
         return f"{self.__class__.__name__}_{'_'.join(params)}.gpkg"
+
+
+def create_utm_zone_grid(
+    area_geometry: Geometry,
+    name_column: str,
+    bbox_size: tuple[int, int],
+    bbox_offset: tuple[int, int],
+    bbox_buffer: tuple[float, float],
+) -> dict[CRS, GeoDataFrame]:
+    """Creates a grid of bounding boxes covering the given area geometry."""
+    splitter = UtmZoneSplitter([area_geometry.geometry], crs=area_geometry.crs, bbox_size=bbox_size, offset=bbox_offset)
+    bbox_list, info_list = splitter.get_bbox_list(), splitter.get_info_list()
+    if bbox_buffer != (0, 0):
+        bbox_list = [bbox.buffer(bbox_buffer, relative=False) for bbox in bbox_list]
+
+    crs_to_patches = defaultdict(list)
+    zfill_length = len(str(len(bbox_list) - 1))
+    for i, (bbox, info) in enumerate(zip(bbox_list, info_list)):
+        i_x, i_y = info["index_x"], info["index_y"]
+        name = f"eopatch-id-{i:0{zfill_length}}-col-{i_x}-row-{i_y}"
+        crs_to_patches[bbox.crs].append((name, bbox.geometry))
+
+    grid = {}
+    for crs, named_bbox_geoms in crs_to_patches.items():
+        names, geoms = zip(*named_bbox_geoms)
+        grid[crs] = gpd.GeoDataFrame({name_column: names}, geometry=list(geoms), crs=crs.pyproj_crs())
+
+    return grid

--- a/eogrow/core/area/utm.py
+++ b/eogrow/core/area/utm.py
@@ -82,7 +82,7 @@ def create_utm_zone_grid(
     area_geometry: Geometry,
     name_column: str,
     bbox_size: tuple[int, int],
-    bbox_offset: tuple[int, int],
+    bbox_offset: tuple[float, float],
     bbox_buffer: tuple[float, float],
 ) -> dict[CRS, GeoDataFrame]:
     """Creates a grid of bounding boxes covering the given area geometry."""

--- a/eogrow/pipelines/download_batch.py
+++ b/eogrow/pipelines/download_batch.py
@@ -348,7 +348,6 @@ def create_batch_grid(
     Creates a grid of bounding boxes covering the given area geometry.
     The format of the grid is suitable for use with Batch V2 Processing API
     """
-
     grid = create_utm_zone_grid(
         area_geometry=area_geometry,
         name_column="identifier",

--- a/eogrow/utils/testing.py
+++ b/eogrow/utils/testing.py
@@ -368,11 +368,11 @@ def compare_content(
         raise ValueError("The given path is None. The pipeline likely has no `output_folder_key` parameter.")
     config = StatCalcConfig() if config is None else config
     stats = calculate_statistics(folder_path, config=config)
+    stats_difference = compare_with_saved(stats, stats_path)
 
     if save_new_stats:
         save_statistics(stats, stats_path)
 
-    stats_difference = compare_with_saved(stats, stats_path)
     if stats_difference:
         stats_difference_repr = stats_difference.to_json(indent=2, sort_keys=True)
         raise AssertionError(f"Expected and obtained stats differ:\n{stats_difference_repr}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,15 +41,16 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Image Processing",
 ]
 dependencies = [
+    'aiohttp_cors<0.8; python_version == "3.8"',
+    "boto3<=1.29.6",
     "click",
     "colorlog",
-    "boto3<=1.29.6",
     "eo-learn[VISUALIZATION]>=1.5.0",
-    "fiona>=1.8.18; python_version>='3.9'",
     "fiona>=1.8.18,<1.10; python_version<'3.9'",
+    "fiona>=1.8.18; python_version>='3.9'",
     "fs>=2.2.0",
-    "geopandas>=0.14.4,<1; python_version>='3.9'",
     "geopandas>=0.11.0,<1; python_version<'3.9'",
+    "geopandas>=0.14.4,<1; python_version>='3.9'",
     "numpy",
     "opencv-python-headless",
     "pandas",
@@ -68,7 +69,7 @@ ml = ["joblib", "lightgbm>=3.0.0", "scikit-learn"]
 docs = [
     "autodoc_pydantic",
     "nbsphinx",
-    "sphinx_mdinclude==0.5.4",  #0.6 didn't work last time
+    "sphinx_mdinclude==0.5.4", #0.6 didn't work last time
     "sphinx-rtd-theme==1.3.0",
     "sphinx==7.1.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ name = "eo-grow"
 dynamic = ["version"]
 description = "Earth observation framework for scaled-up processing in Python"
 readme = "README.md"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 license = { file = "LICENSE" }
 authors = [
     { name = "Sinergise EO research team", email = "eoresearch@sinergise.com" },
@@ -41,16 +41,13 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Image Processing",
 ]
 dependencies = [
-    'aiohttp_cors<0.8; python_version == "3.8"',
     "boto3<=1.29.6",
     "click",
     "colorlog",
     "eo-learn[VISUALIZATION]>=1.5.0",
-    "fiona>=1.8.18,<1.10; python_version<'3.9'",
-    "fiona>=1.8.18; python_version>='3.9'",
+    "fiona>=1.8.18",
     "fs>=2.2.0",
-    "geopandas>=0.11.0,<1; python_version<'3.9'",
-    "geopandas>=0.14.4,<1; python_version>='3.9'",
+    "geopandas>=0.14.4,<1",
     "numpy",
     "opencv-python-headless",
     "pandas",
@@ -80,7 +77,7 @@ dev = [
     "build",
     "deepdiff",
     "fs_s3fs",
-    "numpy>=2.0.0; python_version>='3.9'",
+    "numpy>=2.0.0",
     "moto[s3]>=5.0.0",
     "mypy>=0.990",
     "pre-commit",
@@ -205,6 +202,7 @@ warn_unreachable = true
 strict_equality = true
 pretty = true
 plugins = ["pydantic.mypy"]
+files = ["eogrow"]
 
 [tool.pydantic-mypy]
 # init_forbid_extra = true  # cant be used unless we change managers

--- a/tests/test_config_files/export_maps/export_maps_data.json
+++ b/tests/test_config_files/export_maps/export_maps_data.json
@@ -6,7 +6,7 @@
       "maps": "maps/BANDS-S2-L1C"
     }
   },
-  "input_folder_key": "data_2019",
+  "input_folder_key": "data",
   "output_folder_key": "maps",
   "feature": ["data", "BANDS-S2-L1C"],
   "map_name": "result.tiff",

--- a/tests/test_config_files/export_maps/export_maps_mask.json
+++ b/tests/test_config_files/export_maps/export_maps_mask.json
@@ -6,7 +6,7 @@
       "maps": "maps/CLM"
     }
   },
-  "input_folder_key": "data_2019",
+  "input_folder_key": "data",
   "output_folder_key": "maps",
   "feature": ["mask", "CLM"],
   "map_dtype": "uint16",

--- a/tests/test_config_files/export_maps/export_maps_mask_local_copy.json
+++ b/tests/test_config_files/export_maps/export_maps_mask_local_copy.json
@@ -6,7 +6,7 @@
       "maps": "maps/CLM"
     }
   },
-  "input_folder_key": "data_2019",
+  "input_folder_key": "data",
   "output_folder_key": "maps",
   "feature": ["mask", "CLM"],
   "map_dtype": "uint16",

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1,0 +1,35 @@
+import os
+import re
+from glob import glob
+
+import pytest
+
+import eogrow
+from eogrow.core.config import collect_configs_from_path, interpret_config_from_dict
+from eogrow.utils.meta import load_pipeline_class
+
+IGNORED_FOLDERS = ["other"]
+CONFIG_REGEX = re.compile(r"^(?!global_).*\.json$")
+
+
+def pytest_generate_tests(metafunc):
+    files = glob(os.path.join(eogrow.__path__[0], "..", "tests", "test_config_files", "**", "*.json"), recursive=True)
+    files = [conf_path for conf_path in files if CONFIG_REGEX.match(os.path.split(conf_path)[-1])]
+    files = [conf_path for conf_path in files if not any(folder in conf_path for folder in IGNORED_FOLDERS)]
+    metafunc.parametrize("config_file", files, ids=[path.split("test_config_files/")[-1] for path in files])
+
+
+def test_validate_configs(config_file):
+    crude_config = collect_configs_from_path(config_file)
+    if isinstance(crude_config, list):
+        crude_configs = [conf["pipeline_config"] for conf in crude_config]
+    else:
+        crude_configs = [crude_config]
+
+    for crude_config in crude_configs:
+        pipeline = crude_config.get("pipeline")
+        if pipeline is None:
+            pytest.skip(f"Config with pipeline {pipeline} will be ignored. Skipping.")
+
+        config = interpret_config_from_dict(crude_config)
+        load_pipeline_class(config).Schema.parse_obj(config)


### PR DESCRIPTION
Changes:
- since batch pipeline will use the UTM zone splitter to create a grid, I extracted the logic from the `UtmZoneAreaManager` and put it into `create_utm_zone_grid`
- In the batch download pipeline I created a new function `create_batch_grid` which uses the `create_utm_zone_grid` but also appends some information like width/height/resolution
- in the `UtmZoneAreaManager` grid I added the `id` column and changed a bit how the grid geodataframe is constructed

In the next steps we should update the interface how this information for grid creation come into the pipeline