### PR TITLE
Batch pipeline creates a patch list instead

### DIFF
--- a/eogrow/pipelines/download_batch.py
+++ b/eogrow/pipelines/download_batch.py
@@ -245,7 +245,7 @@ class BatchDownloadPipeline(Pipeline):
 
         if self.config.patch_list is not None:
             LOGGER.info("Constructing the patch list from the feature manifest and execution database")
-            self._save_patch_list(batch_request.request_id)
+            self._save_patch_list(self.config.patch_list, batch_request.request_id)
 
         tiles_dict = self._get_tiles_per_status(batch_request.request_id)
         processed = tiles_dict.get("DONE", [])
@@ -311,7 +311,7 @@ class BatchDownloadPipeline(Pipeline):
             db_df["delivered"] = db_df["delivered"].astype(bool)
             return db_df
 
-    def _save_patch_list(self, batch_request_id: str) -> None:
+    def _save_patch_list(self, patch_list_schema: PatchListSchema, batch_request_id: str) -> None:
         """Creates the patch list using the features manifest."""
         fm_folder = self.storage.get_folder(self.config.output_folder_key)
         fm_path = fs.path.join(fm_folder, f"featureManifest-{batch_request_id}.gpkg")
@@ -325,8 +325,8 @@ class BatchDownloadPipeline(Pipeline):
         not_delivered = set(db_df[~db_df["delivered"]]["name"].tolist())
         patch_list -= not_delivered
 
-        patch_list_folder = self.storage.get_folder(self.config.patch_list.input_folder_key)
-        patch_list_path = fs.path.combine(patch_list_folder, self.config.patch_list.filename)
+        patch_list_folder = self.storage.get_folder(patch_list_schema.input_folder_key)
+        patch_list_path = fs.path.combine(patch_list_folder, patch_list_schema.filename)
         save_names(self.storage.filesystem, patch_list_path, list(patch_list))
 
     def _create_new_batch_request(self) -> BatchProcessRequest:

--- a/eogrow/pipelines/download_batch.py
+++ b/eogrow/pipelines/download_batch.py
@@ -199,8 +199,7 @@ class BatchDownloadPipeline(Pipeline):
                 "existing batch job. If it is not given it will create a new batch job."
             ),
         )
-        patch_list: None = None
-        input_patch_file: None = None
+
         skip_existing: Literal[False] = False
 
     config: Schema

--- a/eogrow/pipelines/download_batch.py
+++ b/eogrow/pipelines/download_batch.py
@@ -301,9 +301,9 @@ class BatchDownloadPipeline(Pipeline):
         db_path = fs.path.join(db_folder, f"execution-{batch_request_id}.sqlite")
         with LocalFile(db_path, mode="r", filesystem=self.storage.filesystem) as local_file:
             conn = sqlite3.connect(local_file.path)
-            df = pd.read_sql("SELECT * FROM features", conn)
-            df["delivered"] = df["delivered"].astype(bool)
-            return df
+            db_df = pd.read_sql("SELECT * FROM features", conn)
+            db_df["delivered"] = db_df["delivered"].astype(bool)
+            return db_df
 
     def _update_batch_grid(self, batch_request_id: str) -> None:
         """Updates the batch grid using the features manifest."""

--- a/eogrow/pipelines/training.py
+++ b/eogrow/pipelines/training.py
@@ -66,8 +66,7 @@ class BaseTrainingPipeline(Pipeline, metaclass=abc.ABCMeta):
             default_factory=dict, description="Parameters to be provided to the model"
         )
         model_filename: str
-        patch_list: None = None
-        input_patch_file: None = None
+
         skip_existing: Literal[False] = False
 
     config: Schema


### PR DESCRIPTION
Changes:
- instead of updating the batch grid, rather save a patch list of valid patches
- valid patches are all patches which which were successfully processed and delivered
    - the user can decide to stop processing if some tiles failed, otherwise to continue
- other pipelines need to define the patch list in order to focus only on available tiles